### PR TITLE
Fix value's display in secrets list and display type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-openapi/runtime v0.19.11
 	github.com/gorilla/websocket v1.4.1
 	github.com/iancoleman/strcase v0.1.3
-	github.com/koyeb/koyeb-api-client-go v0.0.0-20210612053838-a50d2c0e7f5a
+	github.com/koyeb/koyeb-api-client-go v0.0.0-20211013134411-594916edf925
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/koyeb/koyeb-api-client-go v0.0.0-20210612053838-a50d2c0e7f5a h1:ncmwz3MlnuIVimn4YRwMLwBW3jRL7sjCc8xt0SZVW8E=
-github.com/koyeb/koyeb-api-client-go v0.0.0-20210612053838-a50d2c0e7f5a/go.mod h1:uksc9NVH762dNuQBxTKcSG8D/cFdOh6/qGTmRueWpnM=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20211013134411-594916edf925 h1:/R5jCzZgwK2DxjxBfQHXHR6gz7LeGK4RHlCISLDSDuw=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20211013134411-594916edf925/go.mod h1:uksc9NVH762dNuQBxTKcSG8D/cFdOh6/qGTmRueWpnM=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/koyeb/secret.go
+++ b/pkg/koyeb/secret.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/koyeb/koyeb-api-client-go/api/v1/koyeb"
 	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 func NewSecretCmd() *cobra.Command {
@@ -246,7 +247,7 @@ func (a *GetSecretReply) Title() string {
 }
 
 func (a *GetSecretReply) Headers() []string {
-	return []string{"id", "name", "value", "updated_at"}
+	return []string{"id", "name", "type", "value", "updated_at"}
 }
 
 func (a *GetSecretReply) Fields() []map[string]string {
@@ -254,7 +255,11 @@ func (a *GetSecretReply) Fields() []map[string]string {
 	item := a.GetSecret()
 	fields := map[string]string{}
 	for _, field := range a.Headers() {
-		fields[field] = GetField(item, field)
+		if field == "value" {
+			fields[field] = "*****"
+		} else {
+			fields[field] = GetField(item, field)
+		}
 	}
 	res = append(res, fields)
 	return res
@@ -273,7 +278,7 @@ func (a *ListSecretsReply) MarshalBinary() ([]byte, error) {
 }
 
 func (a *ListSecretsReply) Headers() []string {
-	return []string{"id", "name", "value", "updated_at"}
+	return []string{"id", "name", "type", "value", "updated_at"}
 }
 
 func (a *ListSecretsReply) Fields() []map[string]string {
@@ -281,7 +286,11 @@ func (a *ListSecretsReply) Fields() []map[string]string {
 	for _, item := range a.GetSecrets() {
 		fields := map[string]string{}
 		for _, field := range a.Headers() {
-			fields[field] = GetField(item, field)
+			if field == "value" {
+				fields[field] = "*****"
+			} else {
+				fields[field] = GetField(item, field)
+			}
 		}
 		res = append(res, fields)
 	}


### PR DESCRIPTION
Since we added several types of new secret _(`docker_registry`, `private_registry`, etc...)_ their display were broken in the command line.

This pull request aim to fix this behavior by forcing a simple display, so we don't have to handle each type with the current architecture.

Also, we added the type in the output.