### PR TITLE
Print domains as string list for app commands

### DIFF
--- a/pkg/koyeb/apps_describe.go
+++ b/pkg/koyeb/apps_describe.go
@@ -56,7 +56,7 @@ func (r *DescribeAppReply) Fields() []map[string]string {
 	fields := map[string]string{
 		"id":         renderer.FormatAppID(r.mapper, item.GetId(), r.full),
 		"name":       item.GetName(),
-		"domains":    formatDomains(item.GetDomains()),
+		"domains":    formatDomains(item.GetDomains(), 0),
 		"created_at": renderer.FormatTime(item.GetCreatedAt()),
 		"updated_at": renderer.FormatTime(item.GetUpdatedAt()),
 	}

--- a/pkg/koyeb/apps_list.go
+++ b/pkg/koyeb/apps_list.go
@@ -71,7 +71,7 @@ func (r *ListAppsReply) Fields() []map[string]string {
 		fields := map[string]string{
 			"id":         renderer.FormatAppID(r.mapper, item.GetId(), r.full),
 			"name":       item.GetName(),
-			"domains":    formatDomains(item.GetDomains()),
+			"domains":    formatDomains(item.GetDomains(), 80),
 			"created_at": renderer.FormatTime(item.GetCreatedAt()),
 		}
 		resp = append(resp, fields)


### PR DESCRIPTION
Before:

```
$koyeb apps list
ID      	NAME                 	DOMAINS                                                	CREATED AT
8cf805f7	http-server          	http-server-nicolas.koyeb.app                  	22 Sep 21 14:54 UTC
840711c8	someecho2            	someecho2-nicolas.koyeb.app                    	20 Dec 21 13:06 UTC
2fe5c1c9	demodemodemo         	demodemodemo-nicolas.koyeb.app,some.domain.com	03 Jan 22 11:46 UTC
```

After:

```
$koyeb apps list
ID      	NAME                 	DOMAINS                                                      	CREATED AT
8cf805f7	http-server          	["http-server-nicolas.koyeb.app"]                    	22 Sep 21 14:54 UTC
840711c8	someecho2            	["someecho2-nicolas.koyeb.app"]                      	20 Dec 21 13:06 UTC
2fe5c1c9	demodemodemo         	["demodemodemo-nicolas.koyeb.app","some.domain.com"]	03 Jan 22 11:46 UTC
```

lmk what you think of the display @koyeb/core . Suggestions welcome too!