### PR TITLE
Add git-no-deploy-on-push flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/gorilla/websocket v1.5.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/koyeb/koyeb-api-client-go v0.0.0-20220414124849-29f2b2d96c98
+	github.com/koyeb/koyeb-api-client-go v0.0.0-20220601073316-07a2331d9b55
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/koyeb/koyeb-api-client-go v0.0.0-20220414124849-29f2b2d96c98 h1:iQAkV+c3Nib0IyjsaFEBauMc0O4Abp9mkhN8T5f/Cpc=
-github.com/koyeb/koyeb-api-client-go v0.0.0-20220414124849-29f2b2d96c98/go.mod h1:+oQfFj2WL3gi9Pb+UHbob4D7xaT52mPfKyH1UvWa4PQ=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20220601073316-07a2331d9b55 h1:ChwMDy9NejLs+h4MYiYE8ksPX77DQWITW9McaCweNCY=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20220601073316-07a2331d9b55/go.mod h1:+oQfFj2WL3gi9Pb+UHbob4D7xaT52mPfKyH1UvWa4PQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/pkg/koyeb/services.go
+++ b/pkg/koyeb/services.go
@@ -167,6 +167,7 @@ func (h *ServiceHandler) ResolveAppArgs(val string) string {
 func addServiceDefinitionFlags(flags *pflag.FlagSet) {
 	flags.String("git", "", "Git repository")
 	flags.String("git-branch", "", "Git branch")
+	flags.Bool("git-no-deploy-on-push", false, "Disable new deployments creation when code changes are pushed on the configured branch")
 	flags.String("docker", "", "Docker image")
 	flags.String("docker-private-registry-secret", "", "Docker private registry secret")
 	flags.String("docker-command", "", "Docker command")
@@ -298,10 +299,12 @@ func parseServiceDefinitionFlags(flags *pflag.FlagSet, definition *koyeb.Deploym
 		createGitSource := koyeb.NewGitSourceWithDefaults()
 		git, _ := flags.GetString("git")
 		branch, _ := flags.GetString("git-branch")
+		noDeployOnPush, _ := flags.GetBool("git-no-deploy-on-push")
 		createGitSource.SetRepository(git)
 		if branch != "" {
 			createGitSource.SetBranch(branch)
 		}
+		createGitSource.SetNoDeployOnPush(noDeployOnPush)
 		definition.SetGit(*createGitSource)
 		definition.Docker = nil
 	}


### PR DESCRIPTION
The git-no-deploy-on-push flag pause the deployment for git based
services. After setting this option, any new subsequent commits pushed
on the tracked branch won't be taken into account.