### PR TITLE
Change `d` alias for `domain` to `dom`

### DIFF
--- a/pkg/koyeb/domains.go
+++ b/pkg/koyeb/domains.go
@@ -13,7 +13,7 @@ func NewDomainCmd() *cobra.Command {
 
 	domainCmd := &cobra.Command{
 		Use:               "domains ACTION",
-		Aliases:           []string{"d", "domain"},
+		Aliases:           []string{"dom", "domain"},
 		Short:             "Domains",
 		PersistentPreRunE: h.InitHandler,
 	}


### PR DESCRIPTION

This allows `d` to be used for the `deployments` command.