### PR TITLE
Fix completion and help fail when missing config

### DIFF
--- a/pkg/koyeb/koyeb.go
+++ b/pkg/koyeb/koyeb.go
@@ -71,6 +71,11 @@ func isHelpCalled(cmd *cobra.Command) bool {
 	return false
 }
 
+func skipConfigLoading(cmd *cobra.Command) bool {
+	return "" != loginCmd.CalledAs() || "" != versionCmd.CalledAs() ||
+		"" != completionCmd.CalledAs() || isHelpCalled(rootCmd)
+}
+
 func GetRootCmd() *cobra.Command {
 	return rootCmd
 }
@@ -141,7 +146,7 @@ func initConfig() {
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("koyeb")
 
-	if "" != loginCmd.CalledAs() || "" != versionCmd.CalledAs() || "" != completionCmd.CalledAs() || isHelpCalled(rootCmd) {
+	if skipConfigLoading(rootCmd) {
 		return
 	}
 

--- a/pkg/koyeb/koyeb.go
+++ b/pkg/koyeb/koyeb.go
@@ -61,6 +61,16 @@ func genericArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func isHelpCalled(cmd *cobra.Command) bool {
+	for _, subcmd := range cmd.Commands() {
+		if subcmd.Name() == "help" {
+			return subcmd.CalledAs() != ""
+		}
+	}
+
+	return false
+}
+
 func GetRootCmd() *cobra.Command {
 	return rootCmd
 }
@@ -131,7 +141,7 @@ func initConfig() {
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("koyeb")
 
-	if "" != loginCmd.CalledAs() || "" != versionCmd.CalledAs() || "" != completionCmd.CalledAs() {
+	if "" != loginCmd.CalledAs() || "" != versionCmd.CalledAs() || "" != completionCmd.CalledAs() || isHelpCalled(rootCmd) {
 		return
 	}
 

--- a/pkg/koyeb/koyeb.go
+++ b/pkg/koyeb/koyeb.go
@@ -131,7 +131,7 @@ func initConfig() {
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("koyeb")
 
-	if "" != loginCmd.CalledAs() || "" != versionCmd.CalledAs() {
+	if "" != loginCmd.CalledAs() || "" != versionCmd.CalledAs() || "" != completionCmd.CalledAs() {
 		return
 	}
 


### PR DESCRIPTION
This fixes #78 

It bypasses config loading when `koyeb completion` or `koyeb help` is called