### PR TITLE
Jcastets/build dockerfile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.3.0+incompatible
 	github.com/gorilla/websocket v1.5.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/koyeb/koyeb-api-client-go v0.0.0-20230403073954-7eac14253653
+	github.com/koyeb/koyeb-api-client-go v0.0.0-20230529115851-f8d44bf23a92
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/koyeb/koyeb-api-client-go v0.0.0-20230403073954-7eac14253653 h1:JYoabINaiKkM7kqNfnWny7m3csIdt62DmYVN6qiCo8w=
 github.com/koyeb/koyeb-api-client-go v0.0.0-20230403073954-7eac14253653/go.mod h1:+oQfFj2WL3gi9Pb+UHbob4D7xaT52mPfKyH1UvWa4PQ=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20230526002202-99fb3d26845e h1:UiLzSpjUOj0X6zbxbghlDLzwPJ1/UD1S0LBZHXgyaz4=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20230526002202-99fb3d26845e/go.mod h1:+oQfFj2WL3gi9Pb+UHbob4D7xaT52mPfKyH1UvWa4PQ=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20230529115851-f8d44bf23a92 h1:nOOkPFC19x581i+9RS+QeWwULx+sB4ZZ3nGRhiZ8BSY=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20230529115851-f8d44bf23a92/go.mod h1:+oQfFj2WL3gi9Pb+UHbob4D7xaT52mPfKyH1UvWa4PQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/pkg/koyeb/services.go
+++ b/pkg/koyeb/services.go
@@ -204,6 +204,7 @@ func addServiceDefinitionFlags(flags *pflag.FlagSet) {
 
 	flags.String("docker", "", "Docker image")
 	flags.String("docker-private-registry-secret", "", "Docker private registry secret")
+	flags.StringSlice("docker-entrypoint", []string{}, "Docker entrypoint")
 	flags.String("docker-command", "", "Docker command")
 	flags.StringSlice("docker-args", []string{}, "Docker args")
 	flags.StringSlice("regions", []string{"fra"}, "Regions")
@@ -369,6 +370,7 @@ func parseServiceDefinitionFlags(flags *pflag.FlagSet, definition *koyeb.Deploym
 		image, _ := flags.GetString("docker")
 		args, _ := flags.GetStringSlice("docker-args")
 		command, _ := flags.GetString("docker-command")
+		entrypoint, _ := flags.GetStringSlice("docker-entrypoint")
 		image_registry_secret, _ := flags.GetString("docker-private-registry-secret")
 		createDockerSource.SetImage(image)
 		if command != "" {
@@ -379,6 +381,9 @@ func parseServiceDefinitionFlags(flags *pflag.FlagSet, definition *koyeb.Deploym
 		}
 		if len(args) > 0 {
 			createDockerSource.SetArgs(args)
+		}
+		if len(entrypoint) > 0 {
+			createDockerSource.SetEntrypoint(entrypoint)
 		}
 		definition.SetDocker(*createDockerSource)
 		definition.Git = nil


### PR DESCRIPTION
This PR adds several options to `koyeb service create`:

* `--git-builder`, either "buildpack" or "docker" (defaults to "buildpack")
* `--git-buildpack-build-command` and `--git-buildpack-run-command`. The legacy options `--git-build-command` and `--git-run-command` remain for backward compatiblity
* the options `--git-docker-*` to setup the docker builder with the dockerfile, entrypoint, command, args and target

It is also now possible to set the option `--docker-entrypoint`.