### PR TITLE
Add a markdown H1 explicitly to the generated docs

### DIFF
--- a/cmd/gen-doc/gen-doc.go
+++ b/cmd/gen-doc/gen-doc.go
@@ -24,6 +24,8 @@ shortTitle: Reference
 description: "Discover all the commands available via the Koyeb CLI and how to use them to interact with the Koyeb serverless platform directly from the terminal."
 ---
 
+# Koyeb CLI Reference"
+
 The Koyeb CLI allows you to interact with Koyeb directly from the terminal. This documentation references all commands and options available in the CLI.
 
 If you have not installed the Koyeb CLI yet, please read the [installation guide](/docs/cli/installation).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,6 +4,8 @@ shortTitle: Reference
 description: "Discover all the commands available via the Koyeb CLI and how to use them to interact with the Koyeb serverless platform directly from the terminal."
 ---
 
+# Koyeb CLI Reference"
+
 The Koyeb CLI allows you to interact with Koyeb directly from the terminal. This documentation references all commands and options available in the CLI.
 
 If you have not installed the Koyeb CLI yet, please read the [installation guide](/docs/cli/installation).


### PR DESCRIPTION
The new tool we're migrating to for the docs does not automatically generate H1 titles within the page content.  This modifies the intro information so it'll show up on the page.