### PR TITLE
Replace renderer.Format<obj>ID with a generic function

### DIFF
--- a/pkg/koyeb/apps_describe.go
+++ b/pkg/koyeb/apps_describe.go
@@ -69,7 +69,7 @@ func (r *DescribeAppReply) Headers() []string {
 func (r *DescribeAppReply) Fields() []map[string]string {
 	item := r.value.GetApp()
 	fields := map[string]string{
-		"id":         renderer.FormatAppID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"name":       item.GetName(),
 		"status":     formatAppStatus(item.GetStatus()),
 		"domains":    formatDomains(item.GetDomains(), 0),

--- a/pkg/koyeb/apps_get.go
+++ b/pkg/koyeb/apps_get.go
@@ -62,7 +62,7 @@ func (r *GetAppReply) Headers() []string {
 func (r *GetAppReply) Fields() []map[string]string {
 	item := r.value.GetApp()
 	fields := map[string]string{
-		"id":         renderer.FormatAppID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"name":       item.GetName(),
 		"status":     formatAppStatus(item.GetStatus()),
 		"domains":    formatDomains(item.GetDomains(), 80),

--- a/pkg/koyeb/apps_list.go
+++ b/pkg/koyeb/apps_list.go
@@ -73,7 +73,7 @@ func (r *ListAppsReply) Fields() []map[string]string {
 
 	for _, item := range items {
 		fields := map[string]string{
-			"id":         renderer.FormatAppID(r.mapper, item.GetId(), r.full),
+			"id":         renderer.FormatID(item.GetId(), r.full),
 			"name":       item.GetName(),
 			"status":     formatAppStatus(item.GetStatus()),
 			"domains":    formatDomains(item.GetDomains(), 80),

--- a/pkg/koyeb/deployments_describe.go
+++ b/pkg/koyeb/deployments_describe.go
@@ -99,7 +99,7 @@ func (r *DescribeDeploymentReply) Headers() []string {
 func (r *DescribeDeploymentReply) Fields() []map[string]string {
 	item := r.value.GetDeployment()
 	fields := map[string]string{
-		"id":         renderer.FormatDeploymentID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"service":    renderer.FormatServiceSlug(r.mapper, item.GetServiceId(), r.full),
 		"status":     formatDeploymentStatus(item.GetStatus()),
 		"messages":   formatDeploymentMessages(item.GetMessages(), 0),

--- a/pkg/koyeb/deployments_get.go
+++ b/pkg/koyeb/deployments_get.go
@@ -61,7 +61,7 @@ func (r *GetDeploymentReply) Headers() []string {
 func (r *GetDeploymentReply) Fields() []map[string]string {
 	item := r.value.GetDeployment()
 	fields := map[string]string{
-		"id":         renderer.FormatDeploymentID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"service":    renderer.FormatServiceSlug(r.mapper, item.GetServiceId(), r.full),
 		"type":       formatDeploymentType(item.Definition.GetType()),
 		"status":     formatDeploymentStatus(item.GetStatus()),

--- a/pkg/koyeb/deployments_list.go
+++ b/pkg/koyeb/deployments_list.go
@@ -73,7 +73,7 @@ func (r *ListDeploymentsReply) Fields() []map[string]string {
 
 	for _, item := range items {
 		fields := map[string]string{
-			"id":         renderer.FormatDeploymentID(r.mapper, item.GetId(), r.full),
+			"id":         renderer.FormatID(item.GetId(), r.full),
 			"service":    renderer.FormatServiceSlug(r.mapper, item.GetServiceId(), r.full),
 			"type":       formatDeploymentType(item.Definition.GetType()),
 			"status":     formatDeploymentStatus(item.GetStatus()),

--- a/pkg/koyeb/domains_describe.go
+++ b/pkg/koyeb/domains_describe.go
@@ -99,7 +99,7 @@ func (r *DescribeDomainReply) Fields() []map[string]string {
 	item := r.value.GetDomain()
 
 	fields := map[string]string{
-		"id":          renderer.FormatDomainID(r.mapper, item.GetId(), r.full),
+		"id":          renderer.FormatID(item.GetId(), r.full),
 		"name":        item.GetName(),
 		"app":         renderer.FormatAppName(r.mapper, item.GetAppId(), r.full),
 		"status":      string(item.GetStatus()),

--- a/pkg/koyeb/domains_get.go
+++ b/pkg/koyeb/domains_get.go
@@ -60,7 +60,7 @@ func (r *GetDomainReply) Headers() []string {
 func (r *GetDomainReply) Fields() []map[string]string {
 	item := r.value.GetDomain()
 	fields := map[string]string{
-		"id":         renderer.FormatDomainID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"name":       item.GetName(),
 		"app":        renderer.FormatAppName(r.mapper, item.GetAppId(), r.full),
 		"status":     string(item.GetStatus()),

--- a/pkg/koyeb/domains_list.go
+++ b/pkg/koyeb/domains_list.go
@@ -76,7 +76,7 @@ func (r *ListDomainsReply) Fields() []map[string]string {
 
 	for _, item := range items {
 		fields := map[string]string{
-			"id":          renderer.FormatDomainID(r.mapper, item.GetId(), r.full),
+			"id":          renderer.FormatID(item.GetId(), r.full),
 			"name":        item.GetName(),
 			"app":         renderer.FormatAppName(r.mapper, item.GetAppId(), r.full),
 			"status":      string(item.GetStatus()),

--- a/pkg/koyeb/idmapper/app.go
+++ b/pkg/koyeb/idmapper/app.go
@@ -55,25 +55,6 @@ func (mapper *AppMapper) ResolveID(val string) (string, error) {
 	)
 }
 
-func (mapper *AppMapper) GetShortID(id string) (string, error) {
-	if !mapper.fetched {
-		err := mapper.fetch()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	sid, ok := mapper.sidMap.GetValue(id)
-	if !ok {
-		return "", errors.NewCLIErrorForMapperResolve(
-			"application",
-			id,
-			[]string{"application full UUID", "application short ID (8 characters)", "application name"},
-		)
-	}
-	return sid, nil
-}
-
 func (mapper *AppMapper) GetName(id string) (string, error) {
 	if !mapper.fetched {
 		err := mapper.fetch()

--- a/pkg/koyeb/idmapper/deployment.go
+++ b/pkg/koyeb/idmapper/deployment.go
@@ -47,26 +47,6 @@ func (mapper *DeploymentMapper) ResolveID(val string) (string, error) {
 	)
 }
 
-func (mapper *DeploymentMapper) GetShortID(id string) (string, error) {
-	if !mapper.fetched {
-		err := mapper.fetch()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	sid, ok := mapper.sidMap.GetValue(id)
-	if !ok {
-		return "", errors.NewCLIErrorForMapperResolve(
-			"deployments",
-			id,
-			[]string{"deployment full UUID", "deployment short ID (8 characters)"},
-		)
-	}
-
-	return sid, nil
-}
-
 func (mapper *DeploymentMapper) fetch() error {
 	radix := NewRadixTree()
 

--- a/pkg/koyeb/idmapper/domain.go
+++ b/pkg/koyeb/idmapper/domain.go
@@ -56,26 +56,6 @@ func (mapper *DomainMapper) ResolveID(val string) (string, error) {
 	)
 }
 
-func (mapper *DomainMapper) GetShortID(id string) (string, error) {
-	if !mapper.fetched {
-		err := mapper.fetch()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	sid, ok := mapper.sidMap.GetValue(id)
-	if !ok {
-		return "", errors.NewCLIErrorForMapperResolve(
-			"domain",
-			id,
-			[]string{"object full UUID", "object short ID (8 characters)", "domain name"},
-		)
-	}
-
-	return sid, nil
-}
-
 func (mapper *DomainMapper) GetName(id string) (string, error) {
 	if !mapper.fetched {
 		err := mapper.fetch()

--- a/pkg/koyeb/idmapper/instance.go
+++ b/pkg/koyeb/idmapper/instance.go
@@ -47,26 +47,6 @@ func (mapper *InstanceMapper) ResolveID(val string) (string, error) {
 	)
 }
 
-func (mapper *InstanceMapper) GetShortID(id string) (string, error) {
-	if !mapper.fetched {
-		err := mapper.fetch()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	sid, ok := mapper.sidMap.GetValue(id)
-	if !ok {
-		return "", errors.NewCLIErrorForMapperResolve(
-			"instance",
-			id,
-			[]string{"instance full UUID", "instance short ID (8 characters)"},
-		)
-	}
-
-	return sid, nil
-}
-
 func (mapper *InstanceMapper) fetch() error {
 	radix := NewRadixTree()
 

--- a/pkg/koyeb/idmapper/regional_deployment.go
+++ b/pkg/koyeb/idmapper/regional_deployment.go
@@ -47,25 +47,6 @@ func (mapper *RegionalDeploymentMapper) ResolveID(val string) (string, error) {
 	)
 }
 
-func (mapper *RegionalDeploymentMapper) GetShortID(id string) (string, error) {
-	if !mapper.fetched {
-		err := mapper.fetch()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	sid, ok := mapper.sidMap.GetValue(id)
-	if !ok {
-		return "", errors.NewCLIErrorForMapperResolve(
-			"secret",
-			id,
-			[]string{"regional deployment full UUID", "regional deployment short ID (8 characters)"},
-		)
-	}
-	return sid, nil
-}
-
 func (mapper *RegionalDeploymentMapper) fetch() error {
 	radix := NewRadixTree()
 

--- a/pkg/koyeb/idmapper/secret.go
+++ b/pkg/koyeb/idmapper/secret.go
@@ -55,26 +55,6 @@ func (mapper *SecretMapper) ResolveID(val string) (string, error) {
 	)
 }
 
-func (mapper *SecretMapper) GetShortID(id string) (string, error) {
-	if !mapper.fetched {
-		err := mapper.fetch()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	sid, ok := mapper.sidMap.GetValue(id)
-	if !ok {
-		return "", errors.NewCLIErrorForMapperResolve(
-			"secret",
-			id,
-			[]string{"secret full UUID", "secret short ID (8 characters)", "secret name"},
-		)
-	}
-
-	return sid, nil
-}
-
 func (mapper *SecretMapper) fetch() error {
 	radix := NewRadixTree()
 

--- a/pkg/koyeb/idmapper/service.go
+++ b/pkg/koyeb/idmapper/service.go
@@ -57,25 +57,6 @@ func (mapper *ServiceMapper) ResolveID(val string) (string, error) {
 	)
 }
 
-func (mapper *ServiceMapper) GetShortID(id string) (string, error) {
-	if !mapper.fetched {
-		err := mapper.fetch()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	sid, ok := mapper.sidMap.GetValue(id)
-	if !ok {
-		return "", errors.NewCLIErrorForMapperResolve(
-			"service",
-			id,
-			[]string{"service full UUID", "service short ID (8 characters)", "the service name prefixed by the application name and a slash (e.g. my-app/my-service)"},
-		)
-	}
-	return sid, nil
-}
-
 func (mapper *ServiceMapper) GetSlug(id string) (string, error) {
 	if !mapper.fetched {
 		err := mapper.fetch()

--- a/pkg/koyeb/instances_describe.go
+++ b/pkg/koyeb/instances_describe.go
@@ -60,7 +60,7 @@ func (r *DescribeInstanceReply) Headers() []string {
 func (r *DescribeInstanceReply) Fields() []map[string]string {
 	item := r.value.GetInstance()
 	fields := map[string]string{
-		"id":         renderer.FormatInstanceID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"service":    renderer.FormatServiceSlug(r.mapper, item.GetServiceId(), r.full),
 		"status":     formatInstanceStatus(item.GetStatus()),
 		"region":     item.GetRegion(),

--- a/pkg/koyeb/instances_get.go
+++ b/pkg/koyeb/instances_get.go
@@ -61,7 +61,7 @@ func (r *GetInstanceReply) Headers() []string {
 func (r *GetInstanceReply) Fields() []map[string]string {
 	item := r.value.GetInstance()
 	fields := map[string]string{
-		"id":         renderer.FormatInstanceID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"service":    renderer.FormatServiceSlug(r.mapper, item.GetServiceId(), r.full),
 		"status":     formatInstanceStatus(item.GetStatus()),
 		"region":     item.GetRegion(),

--- a/pkg/koyeb/instances_list.go
+++ b/pkg/koyeb/instances_list.go
@@ -123,7 +123,7 @@ func (r *ListInstancesReply) Fields() []map[string]string {
 
 	for _, item := range items {
 		fields := map[string]string{
-			"id":         renderer.FormatInstanceID(r.mapper, item.GetId(), r.full),
+			"id":         renderer.FormatID(item.GetId(), r.full),
 			"service":    renderer.FormatServiceSlug(r.mapper, item.GetServiceId(), r.full),
 			"status":     formatInstanceStatus(item.GetStatus()),
 			"region":     item.GetRegion(),

--- a/pkg/koyeb/regional_deployments_list.go
+++ b/pkg/koyeb/regional_deployments_list.go
@@ -38,7 +38,7 @@ func (r *ListRegionalDeploymentsReply) Fields() []map[string]string {
 
 	for _, item := range items {
 		fields := map[string]string{
-			"id":         renderer.FormatRegionalDeploymentID(r.mapper, item.GetId(), r.full),
+			"id":         renderer.FormatID(item.GetId(), r.full),
 			"region":     item.GetRegion(),
 			"status":     formatRegionalDeploymentStatus(item.GetStatus()),
 			"messages":   formatMessages(item.GetMessages()),

--- a/pkg/koyeb/renderer/format.go
+++ b/pkg/koyeb/renderer/format.go
@@ -10,39 +10,9 @@ func FormatTime(t time.Time) string {
 	return t.Format(time.RFC822)
 }
 
-func FormatAppID(mapper *idmapper.Mapper, id string, full bool) string {
-	if !full {
-		sid, err := mapper.App().GetShortID(id)
-		if err == nil {
-			return sid
-		}
-	}
-	return id
-}
-
 func FormatAppName(mapper *idmapper.Mapper, id string, full bool) string {
 	if !full {
 		sid, err := mapper.App().GetName(id)
-		if err == nil {
-			return sid
-		}
-	}
-	return id
-}
-
-func FormatDomainID(mapper *idmapper.Mapper, id string, full bool) string {
-	if !full {
-		sid, err := mapper.Domain().GetShortID(id)
-		if err == nil {
-			return sid
-		}
-	}
-	return id
-}
-
-func FormatServiceID(mapper *idmapper.Mapper, id string, full bool) string {
-	if !full {
-		sid, err := mapper.Service().GetShortID(id)
 		if err == nil {
 			return sid
 		}
@@ -60,43 +30,10 @@ func FormatServiceSlug(mapper *idmapper.Mapper, id string, full bool) string {
 	return id
 }
 
-func FormatDeploymentID(mapper *idmapper.Mapper, id string, full bool) string {
-	if !full {
-		sid, err := mapper.Deployment().GetShortID(id)
-		if err == nil {
-			return sid
-		}
+// FormatID formats the ID to be displayed in the CLI. If full is false, only the first 8 characters are displayed.
+func FormatID(fullId string, full bool) string {
+	if full {
+		return fullId
 	}
-	return id
-}
-
-func FormatRegionalDeploymentID(mapper *idmapper.Mapper, id string, full bool) string {
-	if !full {
-		sid, err := mapper.RegionalDeployment().GetShortID(id)
-		if err == nil {
-			return sid
-		}
-		panic(err)
-	}
-	return id
-}
-
-func FormatInstanceID(mapper *idmapper.Mapper, id string, full bool) string {
-	if !full {
-		sid, err := mapper.Instance().GetShortID(id)
-		if err == nil {
-			return sid
-		}
-	}
-	return id
-}
-
-func FormatSecretID(mapper *idmapper.Mapper, id string, full bool) string {
-	if !full {
-		sid, err := mapper.Secret().GetShortID(id)
-		if err == nil {
-			return sid
-		}
-	}
-	return id
+	return fullId[:8]
 }

--- a/pkg/koyeb/secrets_describe.go
+++ b/pkg/koyeb/secrets_describe.go
@@ -60,7 +60,7 @@ func (r *DescribeSecretReply) Headers() []string {
 func (r *DescribeSecretReply) Fields() []map[string]string {
 	item := r.value.GetSecret()
 	fields := map[string]string{
-		"id":         renderer.FormatSecretID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"name":       item.GetName(),
 		"type":       formatSecretType(item.GetType()),
 		"value":      "*****",

--- a/pkg/koyeb/secrets_get.go
+++ b/pkg/koyeb/secrets_get.go
@@ -60,7 +60,7 @@ func (r *GetSecretReply) Headers() []string {
 func (r *GetSecretReply) Fields() []map[string]string {
 	item := r.value.GetSecret()
 	fields := map[string]string{
-		"id":         renderer.FormatSecretID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"name":       item.GetName(),
 		"type":       formatSecretType(item.GetType()),
 		"value":      "*****",

--- a/pkg/koyeb/secrets_list.go
+++ b/pkg/koyeb/secrets_list.go
@@ -69,7 +69,7 @@ func (r *ListSecretsReply) Fields() []map[string]string {
 
 	for _, item := range items {
 		fields := map[string]string{
-			"id":         renderer.FormatSecretID(r.mapper, item.GetId(), r.full),
+			"id":         renderer.FormatID(item.GetId(), r.full),
 			"name":       item.GetName(),
 			"type":       formatSecretType(item.GetType()),
 			"value":      "*****",

--- a/pkg/koyeb/services_describe.go
+++ b/pkg/koyeb/services_describe.go
@@ -93,7 +93,7 @@ func (r *DescribeServiceReply) Headers() []string {
 func (r *DescribeServiceReply) Fields() []map[string]string {
 	item := r.value.GetService()
 	fields := map[string]string{
-		"id":         renderer.FormatServiceID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"app":        renderer.FormatAppName(r.mapper, item.GetAppId(), r.full),
 		"name":       item.GetName(),
 		"status":     formatServiceStatus(item.GetStatus()),

--- a/pkg/koyeb/services_get.go
+++ b/pkg/koyeb/services_get.go
@@ -60,7 +60,7 @@ func (r *GetServiceReply) Headers() []string {
 func (r *GetServiceReply) Fields() []map[string]string {
 	item := r.value.GetService()
 	fields := map[string]string{
-		"id":         renderer.FormatServiceID(r.mapper, item.GetId(), r.full),
+		"id":         renderer.FormatID(item.GetId(), r.full),
 		"app":        renderer.FormatAppName(r.mapper, item.GetAppId(), r.full),
 		"name":       item.GetName(),
 		"status":     formatServiceStatus(item.GetStatus()),

--- a/pkg/koyeb/services_list.go
+++ b/pkg/koyeb/services_list.go
@@ -88,7 +88,7 @@ func (r *ListServicesReply) Fields() []map[string]string {
 
 	for _, item := range items {
 		fields := map[string]string{
-			"id":         renderer.FormatServiceID(r.mapper, item.GetId(), r.full),
+			"id":         renderer.FormatID(item.GetId(), r.full),
 			"app":        renderer.FormatAppName(r.mapper, item.GetAppId(), r.full),
 			"name":       item.GetName(),
 			"status":     formatServiceStatus(item.GetStatus()),


### PR DESCRIPTION
The function Format<obj>ID was called to display the UUID of the object in the short form, or the long form if --full is provided. This function was using the idmapper, which lists all the <obj> to return the only object matching the id. This is unnecessary, and instead, we simply return the first 8 digits of the uuid to display the short form.