### PR TITLE
Add a default URL for the api

### DIFF
--- a/pkg/koyeb/koyeb.go
+++ b/pkg/koyeb/koyeb.go
@@ -23,8 +23,8 @@ var (
 	GithubRepo = "koyeb/koyeb-cli"
 
 	// Used for flags.
+	apiurl       = "https://app.koyeb.com"
 	cfgFile      string
-	apiurl       string
 	token        string
 	outputFormat renderer.OutputFormat
 	forceASCII   bool


### PR DESCRIPTION
When running a `version` or `login` command, we get this kind of error:

```
❌ Invalid command: the parameters you provided are invalid

🏥 How to solve the issue?
Run `koyeb --help` to see the list of available commands, or `koyeb <command> --help` to see the help of a specific command

🕦 The original error was:
unsupported schema:
exit status 1
```

Adding a default URL fix the issue