### PR TITLE
feat: add fish completions and update bash completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Use "koyeb [command] --help" for more information about a command.
 
 ### Enabling shell auto-completion
 
-`koyeb` has auto-completion support for `bash` and `zsh`. 
+`koyeb` has auto-completion support for `bash`, `zsh` and `fish`.
 
 #### Bash
 
@@ -121,6 +121,16 @@ koyeb completion zsh > "${fpath[1]}/_koyeb"
 ```
 
 You will need to start a new shell for this setup to take effect.
+
+#### Fish
+
+You can easily run `koyeb completion fish | source` to add completions to your current Fish session.
+
+To automatically load completions for all your shell session, execute once:
+
+```shell
+koyeb completion fish > ~/.config/fish/completions/koyeb.fish
+```
 
 ## Contribute
 

--- a/pkg/koyeb/completion.go
+++ b/pkg/koyeb/completion.go
@@ -7,7 +7,7 @@ import (
 )
 
 var completionCmd = &cobra.Command{
-	Use:   "completion [bash|zsh|powershell]",
+	Use:   "completion [bash|zsh|fish|powershell]",
 	Short: "Generate completion script",
 	Long: `To load completions:
 
@@ -32,16 +32,25 @@ $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 $ koyeb completion zsh > "${fpath[1]}/_koyeb"
 
 # You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ koyeb completion fish | source
+
+# To load completions for each session, execute once:
+$ koyeb completion fish > ~/.config/fish/completions/koyeb.fish
 `,
 	DisableFlagsInUseLine: true,
-	ValidArgs:             []string{"bash", "zsh", "powershell"},
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.ExactValidArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch args[0] {
 		case "bash":
-			return cmd.Root().GenBashCompletion(os.Stdout)
+			return cmd.Root().GenBashCompletionV2(os.Stdout, true)
 		case "zsh":
 			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
 		case "powershell":
 			return cmd.Root().GenPowerShellCompletion(os.Stdout)
 		}


### PR DESCRIPTION
Hi! 
This PR:
* adds fish completions using the existing Cobra framework
* updates bash completions to use [`GenBashCompletionV2()`](https://github.com/spf13/cobra/blob/fd865a44e3c48afeb6a6dbddadb8a5519173e029/site/content/completions/_index.md#bash-completion-v2) instead of `GenBashCompletion()`
* Updates the README

Thanks for all your hard work!