### PR TITLE
Set user agent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+**Unreleased**
+
+Update the user agent from 'OpenAPI-Generator/1.0.0/go' to 'koyeb-cli/version'
+  https://github.com/koyeb/koyeb-cli/pull/149
+
 **v3.3.3**
 
 * Accept the two syntaxes `--app xxx` and `<app>/<service_name>` for koyeb service commands

--- a/pkg/koyeb/client.go
+++ b/pkg/koyeb/client.go
@@ -55,6 +55,7 @@ func getApiClient() (*koyeb.APIClient, error) {
 	log.Debugf("Using host: %s using %s", u.Host, u.Scheme)
 
 	config := koyeb.NewConfiguration()
+	config.UserAgent = "koyeb-cli/" + Version
 	config.Servers[0].URL = u.String()
 	config.HTTPClient = &http.Client{
 		Transport: &DebugTransport{http.DefaultTransport},


### PR DESCRIPTION
Setting user agent to a new format `koyeb-cli/3.3.2`, so in logs we can easily see CLI users.

The old value was generic `"OpenAPI-Generator/1.0.0/go"`


