### PR TITLE
Make sure that we always fetch latest commit sha

### DIFF
--- a/pkg/koyeb/services.go
+++ b/pkg/koyeb/services.go
@@ -165,6 +165,11 @@ $> koyeb service update myapp/myservice --env PORT=8001 --env '!DEBUG'`,
 				updateDef = latestDeploy.GetDeployments()[0].Definition
 			}
 
+			// zero the sha to make sure that the latest sha is fetched
+			if updateDef.Git != nil {
+				updateDef.Git.Sha = koyeb.PtrString("")
+			}
+
 			err = parseServiceDefinitionFlags(cmd.Flags(), updateDef)
 			if err != nil {
 				return err


### PR DESCRIPTION
When we update the service definition we don't want to copy sha from the previous deployment but rather fetch the latest one. For that we need to zero git sha in deployment definiton which will trigger fetching latest change.