### PR TITLE
[ENG-2645] Warn the user if the build logs are from another deployment with the current one having skipped the build

### DIFF
--- a/pkg/koyeb/services_logs.go
+++ b/pkg/koyeb/services_logs.go
@@ -3,8 +3,10 @@ package koyeb
 import (
 	"fmt"
 
-	"github.com/koyeb/koyeb-cli/pkg/koyeb/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/koyeb/koyeb-cli/pkg/koyeb/errors"
 )
 
 func (h *ServiceHandler) Logs(ctx *CLIContext, cmd *cobra.Command, args []string) error {
@@ -31,29 +33,63 @@ func (h *ServiceHandler) Logs(ctx *CLIContext, cmd *cobra.Command, args []string
 	deploymentId := ""
 	instanceId := GetStringFlags(cmd, "instance")
 
-	if logsType == "build" {
-		latestDeploy, resp, err := ctx.Client.DeploymentsApi.ListDeployments(ctx.Context).
-			Limit("1").ServiceId(service).Execute()
-		if err != nil {
-			return errors.NewCLIErrorFromAPIError(
-				fmt.Sprintf("Error while listing the deployments of the service `%s`", serviceName),
-				err,
-				resp,
-			)
+	latestDeployList, resp, err := ctx.Client.DeploymentsApi.ListDeployments(ctx.Context).
+		Limit("1").ServiceId(service).Execute()
+	if err != nil {
+		return errors.NewCLIErrorFromAPIError(
+			fmt.Sprintf("Error while listing the deployments of the service `%s`", serviceName),
+			err,
+			resp,
+		)
+	}
+	if len(latestDeployList.GetDeployments()) == 0 {
+		return &errors.CLIError{
+			What: "Error while fetching the logs of your service",
+			Why:  "we couldn't find the latest deployment of your service",
+			Additional: []string{
+				"Your service exists but has not been deployed yet",
+			},
+			Orig:     nil,
+			Solution: "Try again in a few seconds. If the problem persists, please create an issue on https://github.com/koyeb/koyeb-cli/issues/new",
 		}
-		if len(latestDeploy.GetDeployments()) == 0 {
+	}
+
+	latestDeploymentId := *latestDeployList.GetDeployments()[0].Id
+
+	reply, _, err := ctx.Client.DeploymentsApi.GetDeployment(ctx.Context, latestDeploymentId).Execute()
+	if err != nil {
+		return &errors.CLIError{
+			What: "Error while fetching the logs of your service",
+			Why:  "we couldn't find the latest deployment of your service",
+			Additional: []string{
+				"Your service is nowhere to be found in our systems",
+			},
+			Orig:     nil,
+			Solution: "Please contact us.",
+		}
+	}
+	if reply.Deployment.SkipBuild != nil && *reply.Deployment.SkipBuild {
+		if serviceDetail.Service.LastProvisionedDeploymentId == nil {
 			return &errors.CLIError{
 				What: "Error while fetching the logs of your service",
-				Why:  "we couldn't find the latest deployment of your service",
+				Why:  "we couldn't find the latest provisioned deployment of your service",
 				Additional: []string{
-					"Your service exists but has not been deployed yet",
+					"Your service is nowhere to be found in our systems",
 				},
 				Orig:     nil,
-				Solution: "Try again in a few seconds. If the problem persists, please create an issue on https://github.com/koyeb/koyeb-cli/issues/new",
+				Solution: "Please contact us.",
 			}
 		}
-		deploymentId = *latestDeploy.GetDeployments()[0].Id
+		logrus.Warnf("This deployment uses a previous build originally created during deployment %s. If you want to access those, use `koyeb deployments logs -t build %s`", *serviceDetail.Service.LastProvisionedDeploymentId, *serviceDetail.Service.LastProvisionedDeploymentId)
+		if logsType == "build" {
+			return nil
+		}
 	}
+
+	if logsType == "build" {
+		deploymentId = latestDeploymentId
+	}
+
 	logsQuery, err := ctx.LogsClient.NewWatchLogsQuery(
 		logsType,
 		serviceId,


### PR DESCRIPTION
This PR is needed to properly leverage the possibility to skipping the build. If a user requests the build logs of a service whose current latest deployment is `skip-build`, we warn them that the build logs may be retrieved with `koyeb deployments logs -t build <last_provisioned_deployment_id>`. If the `-t build` is specified in the `koyeb services logs` command, we also early return.