### PR TITLE
Enable to expose ports only on the mesh

### DIFF
--- a/pkg/koyeb/flags_list/ports.go
+++ b/pkg/koyeb/flags_list/ports.go
@@ -60,7 +60,7 @@ func NewPortListFromFlags(values []string) ([]Flag[koyeb.DeploymentPort], error)
 		} else {
 			port.protocol = *koyeb.PtrString("http")
 			if len(split) > 1 {
-				if split[1] != "http" && split[1] != "http2" {
+				if split[1] != "http" && split[1] != "http2" && split[1] != "tcp" {
 					return nil, &errors.CLIError{
 						What: "Error while configuring the service",
 						Why:  fmt.Sprintf("unable to parse the protocol from the port \"%s\"", port.cliValue),


### PR DESCRIPTION
# PROPOSAL, to be discussed

This PR enables the values for `--port` to have also `tcp` specified as protocol. This, together with not defining a `--route` associated to the port, has the equivalent effect as marking the port as not public on the control panel.

The syntax is really a bit hacky, we might want to discuss if this is what we want for the users.