### PR TITLE
Add --git-sha to koyeb service update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
-## v3.13.0 (unreleased)
+## v4.0.0 (unreleased)
 
 * Fix nil dereference in `koyeb deployment logs -t build`.
 * Create new command `koyeb archives create <path>` to store an archive. This command will be necessary for the future deployment of a directory.
 * Add `--archive` parameters to `koyeb service create` and `koyeb service update` to deploy an archive instead of a Docker image. The archive is stored in GCS and can be created with `koyeb archives create`.
 * Add command `koyeb deploy <directory> <app_name>/<service_name>.
+* Allow to specify `--git-sha` in `koyeb service update` and `koyeb service create`. Warning: if the service is deployed with a specific git sha (which is the case if the deployment has been triggered by the "git push" webhook), `koyeb service update` without `--git-sha` will no longer deploy the latest commit, but the commit set in the configuration. To deploy the latest commit, use `koyeb service update --git-sha ''`.
+  - https://github.com/koyeb/koyeb-cli/issues/222
 
 ## v3.12.0 (2024-05-07)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -299,6 +299,7 @@ See examples of koyeb service create --help
       --git-docker-target string                 Docker target
       --git-no-deploy-on-push                    Disable new deployments creation when code changes are pushed on the configured branch
       --git-run-command string                   Run command (legacy, prefer git-buildpack-run-command)
+      --git-sha string                           Git commit SHA to deploy
       --git-workdir string                       Path to the sub-directory containing the code to build and deploy
   -h, --help                                     help for init
       --instance-type string                     Instance type (default "nano")
@@ -1240,6 +1241,7 @@ $> koyeb service create myservice --app myapp --docker nginx --port 80:tcp
       --git-docker-target string                 Docker target
       --git-no-deploy-on-push                    Disable new deployments creation when code changes are pushed on the configured branch
       --git-run-command string                   Run command (legacy, prefer git-buildpack-run-command)
+      --git-sha string                           Git commit SHA to deploy
       --git-workdir string                       Path to the sub-directory containing the code to build and deploy
   -h, --help                                     help for create
       --instance-type string                     Instance type (default "nano")
@@ -1650,6 +1652,7 @@ $> koyeb service update myapp/myservice --port 80:tcp --route '!/'
       --git-docker-target string                 Docker target
       --git-no-deploy-on-push                    Disable new deployments creation when code changes are pushed on the configured branch
       --git-run-command string                   Run command (legacy, prefer git-buildpack-run-command)
+      --git-sha string                           Git commit SHA to deploy
       --git-workdir string                       Path to the sub-directory containing the code to build and deploy
   -h, --help                                     help for update
       --instance-type string                     Instance type (default "nano")


### PR DESCRIPTION
Allow to specify `--git-sha` in `koyeb service update` and `koyeb service create`.

See issue #222 for a full description.