### PR TITLE
unapplied-changes: display "no changes" instead of empty response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## v5.3.0 (unreleased)
 
-* …
+* `koyeb service unapplied-changes <service_id>`: display "no changes" when there is no stashed deployment, or when the stashed deployment is the same as the current deployment.
+  - https://github.com/koyeb/koyeb-cli/pull/259
 
 ## v5.2.0 (2024-10-24)
 


### PR DESCRIPTION
The string "no changes" is displayed when the current deployment is not stashed, or when the stashed deployment has the same definition as the previous non-stashed deployment.