### PR TITLE
Fix changing env variable type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 * `koyeb service unapplied-changes <service_id>`: display "no changes" when there is no stashed deployment, or when the stashed deployment is the same as the current deployment.
   - https://github.com/koyeb/koyeb-cli/pull/259
+* `koyeb service update`: fix when changing the type of an environment variable given with `--type`
+  - https://github.com/koyeb/koyeb-cli/pull/260
 
 ## v5.2.0 (2024-10-24)
 

--- a/pkg/koyeb/flags_list/env.go
+++ b/pkg/koyeb/flags_list/env.go
@@ -78,7 +78,9 @@ func (f *FlagEnv) UpdateItem(env *koyeb.DeploymentEnv) {
 	env.Key = koyeb.PtrString(f.key)
 	if f.isSecret {
 		env.Secret = koyeb.PtrString(f.value)
+		env.Value = nil
 	} else {
+		env.Secret = nil
 		env.Value = koyeb.PtrString(f.value)
 	}
 }


### PR DESCRIPTION
With the following:

	koyeb service update myapp/svc --env MYENV=value
	koyeb service update myapp/svc --env MYENV=@xxx

We used to generate a bad request because this is changing the type of the environment variable MYENV to "plain", then "secret". This is now fixed.