### PR TITLE
Add ARM Linux support in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ set -e
 case $(uname -sm) in
 "Darwin x86_64") target="darwin_amd64" ;;
 "Darwin arm64") target="darwin_arm64" ;;
+"Linux aarch64") target="linux_arm64" ;;
 *) target="linux_amd64" ;;
 esac
 


### PR DESCRIPTION
This adds support for `linux_arm64` machines in the `install.sh` script.