### PR TITLE
idmapper: ensure autoDomainMap has the right entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gofrs/uuid v4.3.0+incompatible
 	github.com/gorilla/websocket v1.5.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/koyeb/koyeb-api-client-go v0.0.0-20250117143439-03648cc5a823
+	github.com/koyeb/koyeb-api-client-go v0.0.0-20250226155650-8b24d170cacf
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/koyeb/koyeb-api-client-go v0.0.0-20250117143439-03648cc5a823 h1:icM+7zADUhhsv1DSXVHdT3UusXWOsZ25aolFPmhgPiU=
 github.com/koyeb/koyeb-api-client-go v0.0.0-20250117143439-03648cc5a823/go.mod h1:+oQfFj2WL3gi9Pb+UHbob4D7xaT52mPfKyH1UvWa4PQ=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20250226155650-8b24d170cacf h1:gSa4eHe3hI/xnImnjfPR+SWgMtAQ9MUgY5WG41WFalE=
+github.com/koyeb/koyeb-api-client-go v0.0.0-20250226155650-8b24d170cacf/go.mod h1:+oQfFj2WL3gi9Pb+UHbob4D7xaT52mPfKyH1UvWa4PQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/koyeb/idmapper/app.go
+++ b/pkg/koyeb/idmapper/app.go
@@ -133,10 +133,18 @@ func (mapper *AppMapper) fetch() error {
 		mapper.sidMap.Set(id, sid)
 		mapper.nameMap.Set(id, name)
 		for _, domain := range domains {
-			if domain.GetType() == koyeb.DOMAINTYPE_AUTOASSIGNED {
-				mapper.autoDomainMap.Set(id, domain.GetId())
-				break
+			if domain.GetType() != koyeb.DOMAINTYPE_AUTOASSIGNED {
+				continue
 			}
+
+			// We want the original autoassigned domain for the app, not other ones that
+			// could have been provisioned with Koyeb Load Balancer, for example
+			if !domain.HasCloudflare() {
+				continue
+			}
+
+			mapper.autoDomainMap.Set(id, domain.GetId())
+			break
 		}
 
 		return nil


### PR DESCRIPTION
With the introduction of LoadBalancer to domains, it's now possible to
have more than 1 autoassigned domain per app. The CLI wants the original
one in some cases.
This commit fixes the idmapper code to ensure we return the original
autoassigned domain and not potential new ones created
