### PR TITLE
Improve secret stdin parsing

### DIFF
--- a/pkg/koyeb/secrets.go
+++ b/pkg/koyeb/secrets.go
@@ -1,7 +1,6 @@
 package koyeb
 
 import (
-	"bufio"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -122,7 +121,7 @@ func NewSecretCmd() *cobra.Command {
 				abort, err = parseAzureRegistry(cmd.Flags(), cfg)
 				secret.SetAzureContainerRegistry(*cfg)
 			default:
-				panic("Unkown secret type:" + flagSecretType)
+				panic("Unknown secret type: " + flagSecretType)
 			}
 			if abort || err != nil {
 				return err
@@ -170,7 +169,7 @@ func NewSecretCmd() *cobra.Command {
 			res, resp, err := ctx.Client.SecretsApi.GetSecret(ctx.Context, secretID).Execute()
 			if err != nil {
 				return errors.NewCLIErrorFromAPIError(
-					fmt.Sprintf("Error while creating the secret `%s`", args[0]),
+					fmt.Sprintf("Error while retrieving the secret `%s`", args[0]),
 					err,
 					resp,
 				)
@@ -197,7 +196,7 @@ func NewSecretCmd() *cobra.Command {
 					abort, err = parseAzureRegistry(cmd.Flags(), registry)
 				}
 			default:
-				panic("Unkown secret type: " + res.Secret.GetType())
+				panic("Unknown secret type: " + res.Secret.GetType())
 			}
 
 			if abort || err != nil {
@@ -255,19 +254,17 @@ func getSecretValue(flags *pflag.FlagSet) (string, bool, error) {
 		password, _ := flags.GetString("value")
 		return password, false, nil
 	} else if flags.Lookup("value-from-stdin").Changed {
-		var input []string
-
-		scanner := bufio.NewScanner(os.Stdin)
-		for {
-			scanner.Scan()
-			text := scanner.Text()
-			if len(text) != 0 {
-				input = append(input, text)
-			} else {
-				break
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", false, &errors.CLIError{
+				What:       "Invalid arguments to create a secret",
+				Why:        "unable to read the secret from stdin",
+				Additional: nil,
+				Orig:       err,
+				Solution:   "Make sure stdin is readable and try again",
 			}
 		}
-		return strings.Join(input, "\n"), false, nil
+		return strings.TrimRight(string(data), "\r\n"), false, nil
 	}
 	prompt := promptui.Prompt{
 		Label: "Enter your secret",

--- a/pkg/koyeb/secrets_test.go
+++ b/pkg/koyeb/secrets_test.go
@@ -1,0 +1,64 @@
+package koyeb
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func secretFlags(t *testing.T, args ...string) *pflag.FlagSet {
+	t.Helper()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	addSecretFlags(flags, nil)
+	require.NoError(t, flags.Parse(args))
+	return flags
+}
+
+func TestGetSecretValueFromStdin(t *testing.T) {
+	input, err := os.CreateTemp(t.TempDir(), "secret-stdin")
+	require.NoError(t, err)
+	_, err = input.WriteString("line 1\n\nline 2\n")
+	require.NoError(t, err)
+	_, err = input.Seek(0, 0)
+	require.NoError(t, err)
+	defer input.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = input
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+
+	value, abort, err := getSecretValue(secretFlags(t, "--value-from-stdin"))
+
+	require.NoError(t, err)
+	assert.False(t, abort)
+	assert.Equal(t, "line 1\n\nline 2", value)
+}
+
+func TestGetSecretValueFromStdinPreservesLongLines(t *testing.T) {
+	input, err := os.CreateTemp(t.TempDir(), "secret-stdin")
+	require.NoError(t, err)
+	_, err = input.WriteString(strings.Repeat("a", 64*1024+1))
+	require.NoError(t, err)
+	_, err = input.Seek(0, 0)
+	require.NoError(t, err)
+	defer input.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = input
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+
+	value, abort, err := getSecretValue(secretFlags(t, "--value-from-stdin"))
+
+	require.NoError(t, err)
+	assert.False(t, abort)
+	assert.Equal(t, strings.Repeat("a", 64*1024+1), value)
+}


### PR DESCRIPTION
## Summary
- Read the full stdin stream for `koyeb secrets create/update --value-from-stdin` instead of stopping at the first blank line.
- Preserve long single-line secret values beyond `bufio.Scanner`'s default token limit.
- Fix a misleading update-path error message and secret-type panic typo.
- Add focused tests for multiline and long stdin secret values.

## Verification
- `git diff --check`
- `go test ./pkg/koyeb -run 'TestGetSecretValueFromStdin'` *(blocked: `go` is not installed in the sandbox)*
