### PR TITLE
Ignore update check failures

### DIFF
--- a/pkg/koyeb/detect_updates.go
+++ b/pkg/koyeb/detect_updates.go
@@ -13,6 +13,8 @@ import (
 
 const DevVersion = "develop"
 
+var detectLatestRelease = selfupdate.DetectLatest
+
 func DetectUpdates() {
 	if Version == DevVersion {
 		return
@@ -32,9 +34,9 @@ func DetectUpdates() {
 			return
 		}
 	}
-	latest, found, err := selfupdate.DetectLatest(GithubRepo)
+	latest, found, err := detectLatestRelease(GithubRepo)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		log.Debugf("unable to detect latest version: %v", err)
 		return
 	}
 	if !found {

--- a/pkg/koyeb/detect_updates_test.go
+++ b/pkg/koyeb/detect_updates_test.go
@@ -1,0 +1,45 @@
+package koyeb
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/rhysd/go-github-selfupdate/selfupdate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectUpdatesIgnoresLatestVersionCheckErrors(t *testing.T) {
+	origVersion := Version
+	origGithubRepo := GithubRepo
+	origStderr := os.Stderr
+	origDetectLatestRelease := detectLatestRelease
+	detectUpdateFile := path.Join(os.TempDir(), "koyeb-cli-detect-update")
+	t.Cleanup(func() {
+		Version = origVersion
+		GithubRepo = origGithubRepo
+		os.Stderr = origStderr
+		detectLatestRelease = origDetectLatestRelease
+		_ = os.Remove(detectUpdateFile)
+	})
+
+	Version = "1.0.0"
+	GithubRepo = "koyeb/koyeb-cli"
+	detectLatestRelease = func(string) (*selfupdate.Release, bool, error) {
+		return nil, false, errors.New("github unavailable")
+	}
+	require.NoError(t, os.RemoveAll(detectUpdateFile))
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	DetectUpdates()
+
+	require.NoError(t, w.Close())
+	stderr, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Empty(t, string(stderr))
+}


### PR DESCRIPTION
## Summary
- Treat GitHub release lookup failures during update detection as non-fatal debug output
- Add a regression test to ensure update-check errors do not write to stderr

## Verification
- `go test ./pkg/koyeb -run TestDetectUpdatesIgnoresLatestVersionCheckErrors -count=1`
- `go test ./pkg/koyeb -count=1`
- `go test ./...`
