### PR TITLE
feat: auto-install shell completions via Homebrew formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,3 +80,4 @@ brews:
       system "#{bin}/koyeb version"
     install: |
       bin.install "koyeb"
+      generate_completions_from_executable(bin/"koyeb", "completion", shells: [:bash, :zsh, :fish])

--- a/pkg/koyeb/completion.go
+++ b/pkg/koyeb/completion.go
@@ -52,7 +52,7 @@ $ koyeb completion fish > ~/.config/fish/completions/koyeb.fish
 		case "fish":
 			return cmd.Root().GenFishCompletion(os.Stdout, true)
 		case "powershell":
-			return cmd.Root().GenPowerShellCompletion(os.Stdout)
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 		}
 		return nil
 	},


### PR DESCRIPTION
## Summary

`brew install koyeb/tap/koyeb` currently installs only the bare binary — no shell completions. The brew formula (auto-generated by goreleaser) only runs `bin.install "koyeb"`.

This PR adds `generate_completions_from_executable` to the goreleaser `brews[].install` template so that Homebrew generates and links bash/zsh/fish completions automatically at `brew install` time.

## Changes

### 1. `fix: include descriptions in powershell completion`
`pkg/koyeb/completion.go` — switch `GenPowerShellCompletion` → `GenPowerShellCompletionWithDesc`.

In cobra v1.5.0, `GenPowerShellCompletion` hardcodes `includeDesc=false` (no descriptions), while bash/zsh/fish already include them. `GenPowerShellCompletionWithDesc` enables them, bringing powershell to parity.

(Note: `GenZshCompletion` in v1.5.0 already calls `genZshCompletion(w, true)` internally, so zsh already had descriptions — no change needed there.)

### 2. `feat: auto-install shell completions via Homebrew formula`
`.goreleaser.yaml` — add to `brews[].install`:

```ruby
generate_completions_from_executable(bin/"koyeb", "completion", shells: [:bash, :zsh, :fish])
```

Homebrew runs `koyeb completion <shell>` at install time and auto-links to:
- `$(brew --prefix)/etc/bash_completion.d/koyeb`
- `$(brew --prefix)/share/zsh/site-functions/_koyeb`
- `$(brew --prefix)/share/fish/vendor_completions.d/koyeb.fish`

PowerShell is omitted — Homebrew doesn't manage it.

## Why this works without config/token

`generate_completions_from_executable` runs the installed binary at `brew install` time with no config file or API token present. `skipConfigLoading()` (`pkg/koyeb/koyeb.go:56-59`) excludes `completionCmd` from config init, so `koyeb completion bash|zsh|fish` exits 0 with valid output even with no `~/.koyeb.yaml`. Verified:

```
$ KOYEB_CONFIG=/tmp/nonexistent.yaml go run ./cmd/koyeb completion bash | head -1
# bash completion V2 for koyeb                                -*- shell-script -*-
```

## Verification

- `go build ./...` ✓
- `koyeb completion bash/zsh/fish/powershell` all produce valid scripts ✓
- powershell output now includes descriptions ✓
- `koyeb completion <shell>` works with no config/token (required for brew install-time generation) ✓

## Timeline

Once merged, the next `v*` tag release will regenerate `Formula/koyeb.rb` (in `koyeb/homebrew-tap`) with the completion line. Users then get completions automatically via `brew install koyeb/tap/koyeb` or `brew upgrade koyeb` — just start a new shell.
