### PR TITLE
fix: authenticate GitHub update checks

### DIFF
--- a/pkg/koyeb/detect_updates.go
+++ b/pkg/koyeb/detect_updates.go
@@ -3,7 +3,9 @@ package koyeb
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -13,7 +15,32 @@ import (
 
 const DevVersion = "develop"
 
-var detectLatestRelease = selfupdate.DetectLatest
+var (
+	ghAuthToken = func() ([]byte, error) {
+		return exec.Command("gh", "auth", "token").Output()
+	}
+	detectLatestRelease = func(slug string) (*selfupdate.Release, bool, error) {
+		updater, err := selfupdate.NewUpdater(selfupdate.Config{APIToken: githubAPIToken()})
+		if err != nil {
+			return nil, false, err
+		}
+		return updater.DetectLatest(slug)
+	}
+)
+
+func githubAPIToken() string {
+	for _, env := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if token := strings.TrimSpace(os.Getenv(env)); token != "" {
+			return token
+		}
+	}
+
+	token, err := ghAuthToken()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(token))
+}
 
 func DetectUpdates() {
 	if Version == DevVersion {

--- a/pkg/koyeb/detect_updates_test.go
+++ b/pkg/koyeb/detect_updates_test.go
@@ -43,3 +43,45 @@ func TestDetectUpdatesIgnoresLatestVersionCheckErrors(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, string(stderr))
 }
+
+func TestGithubAPITokenFromEnvironment(t *testing.T) {
+	origGHAuthToken := ghAuthToken
+	t.Cleanup(func() {
+		ghAuthToken = origGHAuthToken
+	})
+	t.Setenv("GH_TOKEN", "gh-token")
+	t.Setenv("GITHUB_TOKEN", "github-token")
+	ghAuthToken = func() ([]byte, error) {
+		return nil, errors.New("gh should not be called")
+	}
+
+	require.Equal(t, "gh-token", githubAPIToken())
+}
+
+func TestGithubAPITokenFromGHCLI(t *testing.T) {
+	origGHAuthToken := ghAuthToken
+	t.Cleanup(func() {
+		ghAuthToken = origGHAuthToken
+	})
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	ghAuthToken = func() ([]byte, error) {
+		return []byte("gh-cli-token\n"), nil
+	}
+
+	require.Equal(t, "gh-cli-token", githubAPIToken())
+}
+
+func TestGithubAPITokenIgnoresGHCLIError(t *testing.T) {
+	origGHAuthToken := ghAuthToken
+	t.Cleanup(func() {
+		ghAuthToken = origGHAuthToken
+	})
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	ghAuthToken = func() ([]byte, error) {
+		return nil, errors.New("gh is unavailable")
+	}
+
+	require.Empty(t, githubAPIToken())
+}


### PR DESCRIPTION
## Summary
- authenticate automatic GitHub release checks with `GH_TOKEN` when available
- continue supporting `GITHUB_TOKEN`, then fall back to `gh auth token`
- preserve unauthenticated checks when no token source is available
- add coverage for token precedence, GitHub CLI fallback, and fallback errors

## Verification
- `git diff --check`
- targeted Go tests could not be run locally because Go is not installed and the Docker daemon is unavailable

## Alternatives considered
1. **Implemented:** use `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`; this works automatically for existing GitHub CLI users while keeping CI-friendly environment variables.
2. Only document/export `GITHUB_TOKEN=$(gh auth token)`; smallest code change, but requires users to alter every shell/session and does not recognize `GH_TOKEN` directly.
3. Remove or make the automatic release check opt-in; eliminates incidental GitHub API requests, but loses automatic update notifications for most users.
