### PR TITLE
Add workspaces list and --project/--workspace flag

### DIFF
--- a/pkg/koyeb/apps.go
+++ b/pkg/koyeb/apps.go
@@ -19,12 +19,17 @@ func NewAppCmd() *cobra.Command {
 		Aliases: []string{"a", "app"},
 		Short:   "Apps",
 	}
+	appCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	appCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	createAppCmd := &cobra.Command{
 		Use:   "create NAME",
 		Short: "Create app",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			createApp := koyeb.NewCreateAppWithDefaults()
 			SyncFlags(cmd, args, createApp)
 
@@ -46,6 +51,9 @@ func NewAppCmd() *cobra.Command {
 		Example: "See examples of koyeb service create --help",
 		Args:    cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			createApp := koyeb.NewCreateAppWithDefaults()
 
 			createService := koyeb.NewCreateServiceWithDefaults()
@@ -99,6 +107,9 @@ func NewAppCmd() *cobra.Command {
 		Short: "Update app",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			updateApp := koyeb.NewUpdateAppWithDefaults()
 			SyncFlags(cmd, args, updateApp)
 

--- a/pkg/koyeb/apps_delete.go
+++ b/pkg/koyeb/apps_delete.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *AppHandler) Delete(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
+
 	app, err := h.ResolveAppArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/apps_describe.go
+++ b/pkg/koyeb/apps_describe.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *AppHandler) Describe(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
+
 	app, err := h.ResolveAppArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/apps_get.go
+++ b/pkg/koyeb/apps_get.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *AppHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
+
 	app, err := h.ResolveAppArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/apps_list.go
+++ b/pkg/koyeb/apps_list.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *AppHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
+
 	list := []koyeb.AppListItem{}
 
 	page := int64(0)

--- a/pkg/koyeb/apps_pause.go
+++ b/pkg/koyeb/apps_pause.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *AppHandler) Pause(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
+
 	app, err := h.ResolveAppArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/apps_resume.go
+++ b/pkg/koyeb/apps_resume.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *AppHandler) Resume(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
+
 	app, err := h.ResolveAppArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/archives.go
+++ b/pkg/koyeb/archives.go
@@ -14,6 +14,8 @@ func NewArchiveCmd() *cobra.Command {
 		Aliases: []string{"archive"},
 		Short:   "Archives",
 	}
+	archiveCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	archiveCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	createArchiveCmd := &cobra.Command{
 		Use:   "create NAME",

--- a/pkg/koyeb/archives_create.go
+++ b/pkg/koyeb/archives_create.go
@@ -63,6 +63,10 @@ func (h *ArchiveHandler) CreateArchive(ctx *CLIContext, path string) (*koyeb.Cre
 }
 
 func (h *ArchiveHandler) Create(ctx *CLIContext, cmd *cobra.Command, path string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	res, err := h.CreateArchive(ctx, path)
 	if err != nil {
 		return err

--- a/pkg/koyeb/compose.go
+++ b/pkg/koyeb/compose.go
@@ -20,6 +20,9 @@ func NewComposeCmd() *cobra.Command {
 		Example: "koyeb compose ./examples/mesh.yaml",
 		Args:    cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			verbose := GetBoolFlags(cmd, "verbose")
 
 			composeFile, err := parseComposeFile(args[0])
@@ -31,6 +34,8 @@ func NewComposeCmd() *cobra.Command {
 		}),
 	}
 	cmd.Flags().BoolP("verbose", "v", false, "Tails service logs to have more information about your deployment.")
+	cmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	cmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	cmd.AddCommand(NewComposeLogsCmd())
 	cmd.AddCommand(NewComposeDeleteCmd())

--- a/pkg/koyeb/compose_delete.go
+++ b/pkg/koyeb/compose_delete.go
@@ -16,6 +16,9 @@ func NewComposeDeleteCmd() *cobra.Command {
 		Short: "d",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			composeFile, err := parseComposeFile(args[0])
 			if err != nil {
 				return err

--- a/pkg/koyeb/compose_logs.go
+++ b/pkg/koyeb/compose_logs.go
@@ -14,6 +14,9 @@ func NewComposeLogsCmd() *cobra.Command {
 		Short: "l",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			composeFile, err := parseComposeFile(args[0])
 			if err != nil {
 				return err

--- a/pkg/koyeb/deploy.go
+++ b/pkg/koyeb/deploy.go
@@ -22,6 +22,9 @@ func NewDeployCmd() *cobra.Command {
 		Short: "Deploy a directory to Koyeb",
 		Args:  cobra.ExactArgs(2),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			appName, err := serviceHandler.parseAppName(cmd, args[1])
 			if err != nil {
 				return err
@@ -224,6 +227,8 @@ func NewDeployCmd() *cobra.Command {
 	serviceHandler.addServiceDefinitionFlagsForAllSources(deployCmd.Flags())
 	serviceHandler.addServiceDefinitionFlagsForArchiveSource(deployCmd.Flags())
 	serviceHandler.addServiceAccountIdFlag(deployCmd.Flags())
+	deployCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	deployCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 	return deployCmd
 }
 

--- a/pkg/koyeb/deployments.go
+++ b/pkg/koyeb/deployments.go
@@ -13,6 +13,8 @@ func NewDeploymentCmd() *cobra.Command {
 		Aliases: []string{"d", "dep", "depl", "deployment"},
 		Short:   "Deployments",
 	}
+	deploymentCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	deploymentCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	listDeploymentCmd := &cobra.Command{
 		Use:   "list",
@@ -54,6 +56,9 @@ func NewDeploymentCmd() *cobra.Command {
 		Short:   "Get deployment logs",
 		Args:    cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.Logs(ctx, cmd, since.Time, args)
 		}),
 	}

--- a/pkg/koyeb/deployments_cancel.go
+++ b/pkg/koyeb/deployments_cancel.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *DeploymentHandler) Cancel(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	deployment, err := h.ResolveDeploymentArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/deployments_describe.go
+++ b/pkg/koyeb/deployments_describe.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *DeploymentHandler) Describe(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	deployment, err := h.ResolveDeploymentArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/deployments_get.go
+++ b/pkg/koyeb/deployments_get.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *DeploymentHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	deployment, err := h.ResolveDeploymentArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/deployments_list.go
+++ b/pkg/koyeb/deployments_list.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *DeploymentHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	list := []koyeb.DeploymentListItem{}
 
 	appId := ""

--- a/pkg/koyeb/deployments_logs.go
+++ b/pkg/koyeb/deployments_logs.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *DeploymentHandler) Logs(ctx *CLIContext, cmd *cobra.Command, since time.Time, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	deployment, err := h.ResolveDeploymentArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/domains.go
+++ b/pkg/koyeb/domains.go
@@ -12,6 +12,8 @@ func NewDomainCmd() *cobra.Command {
 		Aliases: []string{"dom", "domain"},
 		Short:   "Domains",
 	}
+	domainCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	domainCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	getDomainCmd := &cobra.Command{
 		Use:   "get NAME",

--- a/pkg/koyeb/domains_attach.go
+++ b/pkg/koyeb/domains_attach.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *DomainHandler) Attach(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	domainID, err := ctx.Mapper.Domain().ResolveID(args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/domains_create.go
+++ b/pkg/koyeb/domains_create.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *DomainHandler) Create(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	createDomainReq := koyeb.NewCreateDomainWithDefaults()
 	createDomainReq.SetName(args[0])
 	createDomainReq.SetType(koyeb.DOMAINTYPE_CUSTOM)

--- a/pkg/koyeb/domains_delete.go
+++ b/pkg/koyeb/domains_delete.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *DomainHandler) Delete(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	domain, err := h.ResolveDomainArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/domains_describe.go
+++ b/pkg/koyeb/domains_describe.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *DomainHandler) Describe(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	domain, err := h.ResolveDomainArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/domains_detach.go
+++ b/pkg/koyeb/domains_detach.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *DomainHandler) Detach(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	domainID, err := ctx.Mapper.Domain().ResolveID(args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/domains_get.go
+++ b/pkg/koyeb/domains_get.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *DomainHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	domain, err := h.ResolveDomainArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/domains_list.go
+++ b/pkg/koyeb/domains_list.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *DomainHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	list := []koyeb.Domain{}
 
 	page := int64(0)

--- a/pkg/koyeb/domains_refresh.go
+++ b/pkg/koyeb/domains_refresh.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (h *DomainHandler) Refresh(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	domain, err := h.ResolveDomainArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/idmapper/idmapper.go
+++ b/pkg/koyeb/idmapper/idmapper.go
@@ -18,6 +18,7 @@ type Mapper struct {
 	database     *DatabaseMapper
 	volume       *VolumeMapper
 	snapshot     *SnapshotMapper
+	project      *ProjectMapper
 }
 
 func NewMapper(ctx context.Context, client *koyeb.APIClient) *Mapper {
@@ -32,6 +33,7 @@ func NewMapper(ctx context.Context, client *koyeb.APIClient) *Mapper {
 	databaseMapper := NewDatabaseMapper(ctx, client, appMapper)
 	volumeMapper := NewVolumeMapper(ctx, client)
 	snapshotMapper := NewSnapshotMapper(ctx, client)
+	projectMapper := NewProjectMapper(ctx, client)
 
 	return &Mapper{
 		app:          appMapper,
@@ -45,6 +47,7 @@ func NewMapper(ctx context.Context, client *koyeb.APIClient) *Mapper {
 		database:     databaseMapper,
 		volume:       volumeMapper,
 		snapshot:     snapshotMapper,
+		project:      projectMapper,
 	}
 }
 
@@ -90,4 +93,8 @@ func (mapper *Mapper) Volume() *VolumeMapper {
 
 func (mapper *Mapper) Snapshot() *SnapshotMapper {
 	return mapper.snapshot
+}
+
+func (mapper *Mapper) Project() *ProjectMapper {
+	return mapper.project
 }

--- a/pkg/koyeb/idmapper/project.go
+++ b/pkg/koyeb/idmapper/project.go
@@ -1,0 +1,125 @@
+package idmapper
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/koyeb/koyeb-api-client-go/api/v1/koyeb"
+	"github.com/koyeb/koyeb-cli/pkg/koyeb/errors"
+)
+
+type ProjectMapper struct {
+	ctx     context.Context
+	client  *koyeb.APIClient
+	fetched bool
+	sidMap  *IDMap
+	nameMap *IDMap
+}
+
+func NewProjectMapper(ctx context.Context, client *koyeb.APIClient) *ProjectMapper {
+	return &ProjectMapper{
+		ctx:     ctx,
+		client:  client,
+		fetched: false,
+		sidMap:  NewIDMap(),
+		nameMap: NewIDMap(),
+	}
+}
+
+func (mapper *ProjectMapper) ResolveID(val string) (string, error) {
+	if IsUUIDv4(val) {
+		return val, nil
+	}
+
+	if !mapper.fetched {
+		err := mapper.fetch()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	id, ok := mapper.sidMap.GetID(val)
+	if ok {
+		return id, nil
+	}
+
+	id, ok = mapper.nameMap.GetID(val)
+	if ok {
+		return id, nil
+	}
+
+	return "", errors.NewCLIErrorForMapperResolve(
+		"project",
+		val,
+		[]string{"project full UUID", "project short ID (8 characters)", "project name"},
+	)
+}
+
+func (mapper *ProjectMapper) GetName(id string) (string, error) {
+	if !mapper.fetched {
+		err := mapper.fetch()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	name, ok := mapper.nameMap.GetValue(id)
+	if !ok {
+		return "", nil
+	}
+
+	return name, nil
+}
+
+func (mapper *ProjectMapper) fetch() error {
+	radix := NewRadixTree()
+
+	page := int64(0)
+	offset := int64(0)
+	limit := int64(100)
+	for {
+		res, resp, err := mapper.client.ProjectsApi.ListProjects(mapper.ctx).
+			Limit(strconv.FormatInt(limit, 10)).
+			Offset(strconv.FormatInt(offset, 10)).
+			Execute()
+		if err != nil {
+			return errors.NewCLIErrorFromAPIError(
+				"Error listing projects to resolve the provided identifier to an object ID",
+				err,
+				resp,
+			)
+		}
+
+		projects := res.GetProjects()
+		for i := range projects {
+			project := &projects[i]
+			radix.Insert(getKey(project.GetId()), project)
+		}
+
+		page++
+		offset = page * limit
+		if int64(len(projects)) < limit {
+			break
+		}
+	}
+
+	minLength := radix.MinimalLength(8)
+	err := radix.ForEach(func(key Key, value Value) error {
+		project := value.(*koyeb.Project)
+		id := project.GetId()
+		name := project.GetName()
+		sid := getShortID(id, minLength)
+
+		mapper.sidMap.Set(id, sid)
+		mapper.nameMap.Set(id, name)
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	mapper.fetched = true
+
+	return nil
+}

--- a/pkg/koyeb/instances.go
+++ b/pkg/koyeb/instances.go
@@ -13,6 +13,8 @@ func NewInstanceCmd() *cobra.Command {
 		Aliases: []string{"i", "inst", "instance"},
 		Short:   "Instances",
 	}
+	instanceCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	instanceCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	listInstanceCmd := &cobra.Command{
 		Use:   "list",
@@ -65,6 +67,9 @@ func NewInstanceCmd() *cobra.Command {
 		Short:   "Get instance logs",
 		Args:    cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return instanceHandler.Logs(ctx, cmd, since.Time, args)
 		}),
 	}

--- a/pkg/koyeb/instances_cp.go
+++ b/pkg/koyeb/instances_cp.go
@@ -38,6 +38,10 @@ func (h *InstanceHandler) ExtractFileSpec(ctx *CLIContext, target string) (*File
 }
 
 func (h *InstanceHandler) Cp(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	src, dst := args[0], args[1]
 
 	srcSpec, err := h.ExtractFileSpec(ctx, src)

--- a/pkg/koyeb/instances_describe.go
+++ b/pkg/koyeb/instances_describe.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *InstanceHandler) Describe(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	instance, err := h.ResolveInstanceArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/instances_exec.go
+++ b/pkg/koyeb/instances_exec.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (h *InstanceHandler) Exec(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	instance, err := h.ResolveInstanceArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/instances_get.go
+++ b/pkg/koyeb/instances_get.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *InstanceHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	instance, err := h.ResolveInstanceArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/instances_list.go
+++ b/pkg/koyeb/instances_list.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *InstanceHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	query, err := h.getListQuery(ctx, cmd)
 	if err != nil {
 		return err

--- a/pkg/koyeb/instances_logs.go
+++ b/pkg/koyeb/instances_logs.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *InstanceHandler) Logs(ctx *CLIContext, cmd *cobra.Command, since time.Time, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	instance, err := h.ResolveInstanceArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/koyeb.go
+++ b/pkg/koyeb/koyeb.go
@@ -103,6 +103,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(completionCmd)
 
 	rootCmd.AddCommand(NewOrganizationCmd())
+	rootCmd.AddCommand(NewProjectCmd())
 	rootCmd.AddCommand(NewSecretCmd())
 	rootCmd.AddCommand(NewAppCmd())
 	rootCmd.AddCommand(NewDomainCmd())

--- a/pkg/koyeb/metrics.go
+++ b/pkg/koyeb/metrics.go
@@ -16,6 +16,8 @@ func NewMetricsCmd() *cobra.Command {
 		Aliases: []string{"metric"},
 		Short:   "Metrics",
 	}
+	metricsCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	metricsCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	getMetricsCmd := &cobra.Command{
 		Use:   "get",

--- a/pkg/koyeb/metrics_get.go
+++ b/pkg/koyeb/metrics_get.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (h *MetricsHandler) GetForInstance(ctx *CLIContext, cmd *cobra.Command, instance string, start *time.Time, end *time.Time) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	instanceId, err := h.ResolveInstanceArgs(ctx, instance)
 	if err != nil {
 		return err
@@ -24,6 +28,10 @@ func (h *MetricsHandler) GetForInstance(ctx *CLIContext, cmd *cobra.Command, ins
 }
 
 func (h *MetricsHandler) GetForService(ctx *CLIContext, cmd *cobra.Command, service string, start *time.Time, end *time.Time) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceId, err := h.ResolveServiceArgs(ctx, service)
 	if err != nil {
 		return err
@@ -43,6 +51,10 @@ func (h *MetricsHandler) GetForService(ctx *CLIContext, cmd *cobra.Command, serv
 
 // Implementation of the `get` command. Do not call this function directly, use `GetForInstance` or `GetForService` instead.
 func (h *MetricsHandler) get(ctx *CLIContext, cmd *cobra.Command, metrics [][]string, serviceId string, instanceId string, start *time.Time, end *time.Time) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	full := GetBoolFlags(cmd, "full")
 	renderer := renderer.NewChainRenderer(ctx.Renderer)
 

--- a/pkg/koyeb/organizations.go
+++ b/pkg/koyeb/organizations.go
@@ -16,6 +16,8 @@ func NewOrganizationCmd() *cobra.Command {
 		Aliases: []string{"organizations", "organization", "orgas", "orga", "orgs", "org", "organisations", "organisation"},
 		Short:   "Organization",
 	}
+	rootCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	rootCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List organizations",

--- a/pkg/koyeb/organizations_list.go
+++ b/pkg/koyeb/organizations_list.go
@@ -29,6 +29,10 @@ func getCurrentUserId(ctx *CLIContext) (string, error) {
 }
 
 func (h *OrganizationHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	userId, err := getCurrentUserId(ctx)
 	if err != nil {
 		return err

--- a/pkg/koyeb/organizations_switch.go
+++ b/pkg/koyeb/organizations_switch.go
@@ -7,6 +7,10 @@ import (
 )
 
 func (h *OrganizationHandler) Switch(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	organization, err := ResolveOrganizationArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/projects.go
+++ b/pkg/koyeb/projects.go
@@ -1,0 +1,59 @@
+package koyeb
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewProjectCmd() *cobra.Command {
+	h := NewProjectHandler()
+
+	projectCmd := &cobra.Command{
+		Use:     "workspaces ACTION",
+		Aliases: []string{"workspace", "projects", "project"},
+		Short:   "Workspaces",
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workspaces",
+		RunE:  WithCLIContext(h.List),
+	}
+	projectCmd.AddCommand(listCmd)
+
+	return projectCmd
+}
+
+func NewProjectHandler() *ProjectHandler {
+	return &ProjectHandler{}
+}
+
+type ProjectHandler struct{}
+
+func (h *ProjectHandler) ResolveProjectArgs(ctx *CLIContext, val string) (string, error) {
+	projectMapper := ctx.Mapper.Project()
+	id, err := projectMapper.ResolveID(val)
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// setProjectHeader resolves the --project/--workspace flag (if set) and sets
+// the x-koyeb-project-id header on the API client config so all subsequent
+// requests are scoped to that workspace.
+func setProjectHeader(ctx *CLIContext, cmd *cobra.Command) error {
+	projectFlag := GetStringFlags(cmd, "project")
+	if projectFlag == "" {
+		projectFlag = GetStringFlags(cmd, "workspace")
+	}
+	if projectFlag == "" {
+		return nil
+	}
+	projectHandler := NewProjectHandler()
+	projectId, err := projectHandler.ResolveProjectArgs(ctx, projectFlag)
+	if err != nil {
+		return err
+	}
+	ctx.Client.GetConfig().AddDefaultHeader("x-koyeb-project-id", projectId)
+	return nil
+}

--- a/pkg/koyeb/projects_list.go
+++ b/pkg/koyeb/projects_list.go
@@ -1,0 +1,90 @@
+package koyeb
+
+import (
+	"strconv"
+
+	"github.com/koyeb/koyeb-api-client-go/api/v1/koyeb"
+	"github.com/koyeb/koyeb-cli/pkg/koyeb/errors"
+	"github.com/koyeb/koyeb-cli/pkg/koyeb/idmapper"
+	"github.com/koyeb/koyeb-cli/pkg/koyeb/renderer"
+	"github.com/spf13/cobra"
+)
+
+func (h *ProjectHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
+	list := []koyeb.Project{}
+
+	page := int64(0)
+	offset := int64(0)
+	limit := int64(100)
+	for {
+		res, resp, err := ctx.Client.ProjectsApi.ListProjects(ctx.Context).
+			Limit(strconv.FormatInt(limit, 10)).Offset(strconv.FormatInt(offset, 10)).Execute()
+		if err != nil {
+			return errors.NewCLIErrorFromAPIError(
+				"Error while listing the projects",
+				err,
+				resp,
+			)
+		}
+		list = append(list, res.GetProjects()...)
+
+		page++
+		offset = page * limit
+		if int64(len(res.GetProjects())) < limit {
+			break
+		}
+	}
+
+	full := GetBoolFlags(cmd, "full")
+	listProjectsReply := NewListProjectsReply(ctx.Mapper, &koyeb.ListProjectsReply{Projects: list}, full)
+	ctx.Renderer.Render(listProjectsReply)
+	return nil
+}
+
+type ListProjectsReply struct {
+	mapper *idmapper.Mapper
+	value  *koyeb.ListProjectsReply
+	full   bool
+}
+
+func NewListProjectsReply(mapper *idmapper.Mapper, value *koyeb.ListProjectsReply, full bool) *ListProjectsReply {
+	return &ListProjectsReply{
+		mapper: mapper,
+		value:  value,
+		full:   full,
+	}
+}
+
+func (ListProjectsReply) Title() string {
+	return "Workspaces"
+}
+
+func (r *ListProjectsReply) MarshalBinary() ([]byte, error) {
+	return r.value.MarshalJSON()
+}
+
+func (r *ListProjectsReply) Headers() []string {
+	return []string{"id", "name", "description", "services", "created_at"}
+}
+
+func (r *ListProjectsReply) Fields() []map[string]string {
+	items := r.value.GetProjects()
+	resp := make([]map[string]string, 0, len(items))
+
+	for _, item := range items {
+		fields := map[string]string{
+			"id":          renderer.FormatID(item.GetId(), r.full),
+			"name":        item.GetName(),
+			"description": item.GetDescription(),
+			"services":    item.GetServiceCount(),
+			"created_at":  renderer.FormatTime(item.GetCreatedAt()),
+		}
+		resp = append(resp, fields)
+	}
+
+	return resp
+}

--- a/pkg/koyeb/regional_deployments.go
+++ b/pkg/koyeb/regional_deployments.go
@@ -12,6 +12,8 @@ func NewRegionalDeploymentCmd() *cobra.Command {
 		Aliases: []string{"rd", "rdep", "rdepl", "rdeploy", "rdeployment", "regional-deployment"},
 		Short:   "Regional deployments",
 	}
+	regionalDeploymentCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	regionalDeploymentCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	listRegionalDeploymentCmd := &cobra.Command{
 		Use:   "list",

--- a/pkg/koyeb/regional_deployments_get.go
+++ b/pkg/koyeb/regional_deployments_get.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *RegionalDeploymentHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	regionalDeployment, err := h.ResolveRegionalDeploymentArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/regional_deployments_list.go
+++ b/pkg/koyeb/regional_deployments_list.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *RegionalDeploymentHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	list := []koyeb.RegionalDeploymentListItem{}
 
 	deploymentId := ""

--- a/pkg/koyeb/sandbox.go
+++ b/pkg/koyeb/sandbox.go
@@ -34,6 +34,8 @@ Sandboxes are created using 'koyeb service create --type=sandbox'.
 These commands provide additional functionality for running commands,
 managing processes, filesystem operations, and port exposure.`,
 	}
+	sandboxCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	sandboxCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	// list command - list all sandboxes
 	listSandboxCmd := &cobra.Command{

--- a/pkg/koyeb/sandbox_create.go
+++ b/pkg/koyeb/sandbox_create.go
@@ -12,6 +12,10 @@ import (
 
 // Create creates a new sandbox service with appropriate defaults
 func (h *SandboxHandler) Create(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	createService := koyeb.NewCreateServiceWithDefaults()
 	createDefinition := koyeb.NewDeploymentDefinitionWithDefaults()
 

--- a/pkg/koyeb/sandbox_fs.go
+++ b/pkg/koyeb/sandbox_fs.go
@@ -19,6 +19,10 @@ const (
 
 // FsRead reads a file from the sandbox
 func (h *SandboxHandler) FsRead(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	path := args[1]
 
@@ -47,6 +51,10 @@ func (h *SandboxHandler) FsRead(ctx *CLIContext, cmd *cobra.Command, args []stri
 
 // FsWrite writes content to a file in the sandbox
 func (h *SandboxHandler) FsWrite(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	path := args[1]
 
@@ -110,6 +118,10 @@ func (h *SandboxHandler) FsWrite(ctx *CLIContext, cmd *cobra.Command, args []str
 
 // FsLs lists directory contents in the sandbox
 func (h *SandboxHandler) FsLs(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	path := "."
 	if len(args) >= 2 {
@@ -185,6 +197,10 @@ func (h *SandboxHandler) FsLs(ctx *CLIContext, cmd *cobra.Command, args []string
 
 // FsMkdir creates a directory in the sandbox
 func (h *SandboxHandler) FsMkdir(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	path := args[1]
 
@@ -212,6 +228,10 @@ func (h *SandboxHandler) FsMkdir(ctx *CLIContext, cmd *cobra.Command, args []str
 
 // FsRm removes a file or directory from the sandbox
 func (h *SandboxHandler) FsRm(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	path := args[1]
 
@@ -264,6 +284,10 @@ func (h *SandboxHandler) FsRm(ctx *CLIContext, cmd *cobra.Command, args []string
 
 // FsUpload uploads a local file or directory to the sandbox
 func (h *SandboxHandler) FsUpload(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	localPath := args[1]
 	remotePath := args[2]
@@ -440,6 +464,10 @@ func (h *SandboxHandler) uploadDirectory(ctx context.Context, client *SandboxCli
 
 // FsDownload downloads a file from the sandbox
 func (h *SandboxHandler) FsDownload(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	remotePath := args[1]
 	localPath := args[2]

--- a/pkg/koyeb/sandbox_list.go
+++ b/pkg/koyeb/sandbox_list.go
@@ -12,6 +12,10 @@ import (
 
 // List lists all sandbox services
 func (h *SandboxHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	list := []koyeb.ServiceListItem{}
 
 	// Parse flags once before the loop

--- a/pkg/koyeb/sandbox_port.go
+++ b/pkg/koyeb/sandbox_port.go
@@ -10,6 +10,10 @@ import (
 
 // ExposePort binds a port to the TCP proxy
 func (h *SandboxHandler) ExposePort(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	portStr := args[1]
 
@@ -70,6 +74,10 @@ func (h *SandboxHandler) ExposePort(ctx *CLIContext, cmd *cobra.Command, args []
 
 // UnexposePort unbinds the current port from the TCP proxy
 func (h *SandboxHandler) UnexposePort(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 
 	info, err := h.GetSandboxInfo(ctx, sandboxName)

--- a/pkg/koyeb/sandbox_process.go
+++ b/pkg/koyeb/sandbox_process.go
@@ -13,6 +13,10 @@ import (
 
 // StartProcess starts a background process in the sandbox
 func (h *SandboxHandler) StartProcess(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	command := strings.Join(args[1:], " ")
 
@@ -77,6 +81,10 @@ func (h *SandboxHandler) StartProcess(ctx *CLIContext, cmd *cobra.Command, args 
 
 // ListProcesses lists background processes in the sandbox
 func (h *SandboxHandler) ListProcesses(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 
 	info, err := h.GetSandboxInfo(ctx, sandboxName)
@@ -110,6 +118,10 @@ func (h *SandboxHandler) ListProcesses(ctx *CLIContext, cmd *cobra.Command, args
 
 // KillProcess kills a background process in the sandbox
 func (h *SandboxHandler) KillProcess(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	processID := args[1]
 
@@ -137,6 +149,10 @@ func (h *SandboxHandler) KillProcess(ctx *CLIContext, cmd *cobra.Command, args [
 
 // ProcessLogs streams logs from a background process
 func (h *SandboxHandler) ProcessLogs(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	processID := args[1]
 

--- a/pkg/koyeb/sandbox_run.go
+++ b/pkg/koyeb/sandbox_run.go
@@ -14,6 +14,10 @@ import (
 
 // Run executes a command in the sandbox
 func (h *SandboxHandler) Run(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	sandboxName := args[0]
 	command := strings.Join(args[1:], " ")
 

--- a/pkg/koyeb/services.go
+++ b/pkg/koyeb/services.go
@@ -24,6 +24,8 @@ func NewServiceCmd() *cobra.Command {
 		Aliases: []string{"s", "svc", "service"},
 		Short:   "Services",
 	}
+	serviceCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	serviceCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	createServiceCmd := &cobra.Command{
 		Use:   "create NAME",
@@ -46,6 +48,9 @@ $> koyeb service create myservice --app myapp --git github.com/org/name --git-br
 $> koyeb service create myservice --app myapp --docker nginx --port 80:tcp
 `,
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			createService := koyeb.NewCreateServiceWithDefaults()
 			createDefinition := koyeb.NewDeploymentDefinitionWithDefaults()
 
@@ -119,6 +124,9 @@ $> koyeb service create myservice --app myapp --docker nginx --port 80:tcp
 		Short:   "Get the service logs",
 		Args:    cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.Logs(ctx, cmd, since.Time, args)
 		}),
 	}
@@ -178,6 +186,9 @@ $> koyeb service update myapp/myservice --docker-command nginx --docker-args '-g
 $> koyeb service update myapp/myservice --port 80:tcp --route '!/'
 `,
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			serviceName, err := h.parseServiceName(cmd, args[0])
 			if err != nil {
 				return err

--- a/pkg/koyeb/services_create.go
+++ b/pkg/koyeb/services_create.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *ServiceHandler) Create(ctx *CLIContext, cmd *cobra.Command, args []string, createService *koyeb.CreateService) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	appID, err := h.parseAppName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_delete.go
+++ b/pkg/koyeb/services_delete.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *ServiceHandler) Delete(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_describe.go
+++ b/pkg/koyeb/services_describe.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (h *ServiceHandler) Describe(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_exec.go
+++ b/pkg/koyeb/services_exec.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (h *ServiceHandler) Exec(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_get.go
+++ b/pkg/koyeb/services_get.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *ServiceHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_list.go
+++ b/pkg/koyeb/services_list.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *ServiceHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	list := []koyeb.ServiceListItem{}
 
 	page := int64(0)

--- a/pkg/koyeb/services_logs.go
+++ b/pkg/koyeb/services_logs.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *ServiceHandler) Logs(ctx *CLIContext, cmd *cobra.Command, since time.Time, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_pause.go
+++ b/pkg/koyeb/services_pause.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *ServiceHandler) Pause(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_redeploy.go
+++ b/pkg/koyeb/services_redeploy.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *ServiceHandler) ReDeploy(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_resume.go
+++ b/pkg/koyeb/services_resume.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *ServiceHandler) Resume(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_scale.go
+++ b/pkg/koyeb/services_scale.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *ServiceHandler) Scale(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_scale_delete.go
+++ b/pkg/koyeb/services_scale_delete.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *ServiceHandler) DeleteScale(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_scale_get.go
+++ b/pkg/koyeb/services_scale_get.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *ServiceHandler) GetScale(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_scale_update.go
+++ b/pkg/koyeb/services_scale_update.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (h *ServiceHandler) UpdateScale(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_show_unapplied_changes.go
+++ b/pkg/koyeb/services_show_unapplied_changes.go
@@ -14,6 +14,10 @@ import (
 )
 
 func (h *ServiceHandler) ShowUnappliedChanges(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/services_update.go
+++ b/pkg/koyeb/services_update.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *ServiceHandler) Update(ctx *CLIContext, cmd *cobra.Command, args []string, updateService *koyeb.UpdateService) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	serviceName, err := h.parseServiceName(cmd, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/snapshots.go
+++ b/pkg/koyeb/snapshots.go
@@ -15,12 +15,17 @@ func NewSnapshotCmd() *cobra.Command {
 		Aliases: []string{"vol", "snapshot"},
 		Short:   "Manage snapshots",
 	}
+	snapshotCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	snapshotCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	createSnapshotCmd := &cobra.Command{
 		Use:   "create NAME PARENT_VOLUME",
 		Short: "Create a new snapshot",
 		Args:  cobra.ExactArgs(2),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			req := koyeb.NewCreateSnapshotRequestWithDefaults()
 
 			parentVolumeID, err := ctx.Mapper.Volume().ResolveID(args[1])
@@ -41,6 +46,9 @@ func NewSnapshotCmd() *cobra.Command {
 		Short: "Get a snapshot",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.Get(ctx, cmd, args)
 		}),
 	}
@@ -50,6 +58,9 @@ func NewSnapshotCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List snapshots",
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.List(ctx, cmd, args)
 		}),
 	}
@@ -60,6 +71,9 @@ func NewSnapshotCmd() *cobra.Command {
 		Short: "Update a snapshot",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			req := koyeb.NewUpdateSnapshotRequestWithDefaults()
 
 			name, _ := cmd.Flags().GetString("name")
@@ -78,6 +92,9 @@ func NewSnapshotCmd() *cobra.Command {
 		Short: "Delete a snapshot",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.Delete(ctx, cmd, args)
 		}),
 	}

--- a/pkg/koyeb/snapshots_create.go
+++ b/pkg/koyeb/snapshots_create.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *SnapshotHandler) Create(ctx *CLIContext, cmd *cobra.Command, args []string, createSnapshot *koyeb.CreateSnapshotRequest) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	res, resp, err := ctx.Client.SnapshotsApi.CreateSnapshot(ctx.Context).Body(*createSnapshot).Execute()
 	if err != nil {
 		return errors.NewCLIErrorFromAPIError(

--- a/pkg/koyeb/snapshots_delete.go
+++ b/pkg/koyeb/snapshots_delete.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *SnapshotHandler) Delete(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	snapshot, err := ResolveSnapshotArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/snapshots_get.go
+++ b/pkg/koyeb/snapshots_get.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *SnapshotHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	snapshot, err := ResolveSnapshotArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/snapshots_list.go
+++ b/pkg/koyeb/snapshots_list.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *SnapshotHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	list := []koyeb.Snapshot{}
 
 	page := int64(0)

--- a/pkg/koyeb/snapshots_update.go
+++ b/pkg/koyeb/snapshots_update.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *SnapshotHandler) Update(ctx *CLIContext, cmd *cobra.Command, args []string, snapshot *koyeb.UpdateSnapshotRequest) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	id, err := ResolveSnapshotArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/volumes.go
+++ b/pkg/koyeb/volumes.go
@@ -21,12 +21,17 @@ func NewVolumeCmd() *cobra.Command {
 		Aliases: []string{"vol", "volume"},
 		Short:   "Manage persistent volumes",
 	}
+	volumeCmd.PersistentFlags().StringP("project", "p", "", "Workspace ID or name")
+	volumeCmd.PersistentFlags().String("workspace", "", "Workspace ID or name (alias for --project)")
 
 	createVolumeCmd := &cobra.Command{
 		Use:   "create NAME",
 		Short: "Create a new volume",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			req := koyeb.NewCreatePersistentVolumeRequestWithDefaults()
 
 			req.SetName(args[0])
@@ -107,6 +112,9 @@ func NewVolumeCmd() *cobra.Command {
 		Short: "Get a volume",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.Get(ctx, cmd, args)
 		}),
 	}
@@ -116,6 +124,9 @@ func NewVolumeCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List volumes",
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.List(ctx, cmd, args)
 		}),
 	}
@@ -126,6 +137,9 @@ func NewVolumeCmd() *cobra.Command {
 		Short: "Update a volume",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			req := koyeb.NewUpdatePersistentVolumeRequestWithDefaults()
 
 			name, _ := cmd.Flags().GetString("name")
@@ -153,6 +167,9 @@ func NewVolumeCmd() *cobra.Command {
 		Short: "Delete a volume",
 		Args:  cobra.ExactArgs(1),
 		RunE: WithCLIContext(func(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+			if err := setProjectHeader(ctx, cmd); err != nil {
+				return err
+			}
 			return h.Delete(ctx, cmd, args)
 		}),
 	}

--- a/pkg/koyeb/volumes_create.go
+++ b/pkg/koyeb/volumes_create.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *VolumeHandler) Create(ctx *CLIContext, cmd *cobra.Command, args []string, createVolume *koyeb.CreatePersistentVolumeRequest) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	res, resp, err := ctx.Client.PersistentVolumesApi.CreatePersistentVolume(ctx.Context).Body(*createVolume).Execute()
 	if err != nil {
 		return errors.NewCLIErrorFromAPIError(

--- a/pkg/koyeb/volumes_delete.go
+++ b/pkg/koyeb/volumes_delete.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *VolumeHandler) Delete(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	volume, err := ResolveVolumeArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/volumes_get.go
+++ b/pkg/koyeb/volumes_get.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (h *VolumeHandler) Get(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	volume, err := ResolveVolumeArgs(ctx, args[0])
 	if err != nil {
 		return err

--- a/pkg/koyeb/volumes_list.go
+++ b/pkg/koyeb/volumes_list.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (h *VolumeHandler) List(ctx *CLIContext, cmd *cobra.Command, args []string) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	list := []koyeb.PersistentVolume{}
 
 	page := int64(0)

--- a/pkg/koyeb/volumes_update.go
+++ b/pkg/koyeb/volumes_update.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (h *VolumeHandler) Update(ctx *CLIContext, cmd *cobra.Command, args []string, volume *koyeb.UpdatePersistentVolumeRequest) error {
+
+	if err := setProjectHeader(ctx, cmd); err != nil {
+		return err
+	}
 	id, err := ResolveVolumeArgs(ctx, args[0])
 	if err != nil {
 		return err


### PR DESCRIPTION
## Usage

### List workspaces

```
$ koyeb workspaces list
```
```
ID       NAME     DESCRIPTION                                    SERVICES  CREATED AT
cf25ce94 default  Initial project created with your organization  44        25 Feb 26 17:05 UTC
```

Also works as `koyeb projects list` (alias).

### Filter apps by workspace

```
$ koyeb apps list --project default
```

```
ID       NAME              STATUS   DOMAINS                              CREATED AT
dfdaf347 qualified-elga     HEALTHY  ["hey.koyeb.app"]                    26 Nov 25 11:22 UTC
578138ff puny-caril        PAUSED   ["mistral.koyeb.app"]               03 Dec 25 11:38 UTC
6c0a0a64 deployment-times  HEALTHY  ["deployment-times.koyeb.app"]       14 Jan 26 16:51 UTC
```

The `--project` (or `--workspace`) flag accepts a **short ID** (8 chars), **full UUID**, or **workspace name**. It is available on all command groups: `apps`, `services`, `deployments`, `regional-deployments`, `instances`, `domains`, `volumes`, `snapshots`, `organizations`, `metrics`, `deploy`, `compose`, `sandbox`, `archive`.